### PR TITLE
ci: enforce conventions and automate release drafts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
-## O que mudou?
+## PR title
 
-## Por que mudou?
+Use: `<type>(<scope>): <summary>`
+Example: `fix(typecheck): reject now() in deterministic pipelines`
+
+## What changed?
+
+## Why changed?
 
 ## Checklist
 
-- [ ] Documentação atualizada
-- [ ] Escopo limitado e claro
-- [ ] Título descritivo
+- [ ] Local CI executed: `./scripts/ci-local.sh`
+- [ ] Scope is clear and limited
+- [ ] Documentation updated (if needed)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE (#$NUMBER)"
+no-changes-template: "- No significant changes in this release."
+
+categories:
+  - title: "Features"
+    labels: ["feat"]
+  - title: "Fixes"
+    labels: ["fix"]
+  - title: "Documentation"
+    labels: ["docs"]
+  - title: "Refactor"
+    labels: ["refactor"]
+  - title: "Tests"
+    labels: ["test"]
+  - title: "CI"
+    labels: ["ci"]
+  - title: "Chore"
+    labels: ["chore"]
+
+change-title-escapes: "<>*&#@"
+version-resolver:
+  major:
+    labels: ["breaking"]
+  minor:
+    labels: ["feat"]
+  patch:
+    labels: ["fix", "docs", "refactor", "test", "ci", "chore"]
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,46 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     steps:
-      - name: Validate PR title convention (warning only)
+      - name: Validate PR title convention
         run: |
           title="${{ github.event.pull_request.title }}"
-          pattern='^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._-]+\))?: .+'
+          pattern='^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._/-]+\))?: .+'
           if echo "$title" | grep -Eq "$pattern"; then
             echo "PR title convention: ok"
           else
-            echo "::warning title=PR title convention::Use Conventional Commits style in PR title: <type>(<scope>): <summary>"
-            echo "Current title: $title"
+            echo "PR title does not follow Conventional Commits style"
+            echo "Expected: <type>(<scope>): <summary>"
+            echo "Current:  $title"
+            exit 1
+          fi
+
+  commit-message-convention:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages in PR
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          range="origin/${{ github.base_ref }}..HEAD"
+          pattern='^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._/-]+\))?: .+'
+          bad=0
+          while IFS= read -r msg; do
+            if ! echo "$msg" | grep -Eq "$pattern"; then
+              echo "Invalid commit message: $msg"
+              bad=1
+            fi
+          done < <(git log --pretty=%s "$range")
+
+          if [ "$bad" -ne 0 ]; then
+            echo "One or more commit messages do not follow Conventional Commits"
+            exit 1
           fi
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pr-title-convention:
@@ -42,28 +43,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout full history
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Validate commit messages in PR
-        run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          range="origin/${{ github.base_ref }}..HEAD"
-          pattern='^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._/-]+\))?: .+'
-          bad=0
-          while IFS= read -r msg; do
-            if ! echo "$msg" | grep -Eq "$pattern"; then
-              echo "Invalid commit message: $msg"
-              bad=1
-            fi
-          done < <(git log --pretty=%s "$range")
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pattern = /^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._/-]+\))?: .+/;
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
 
-          if [ "$bad" -ne 0 ]; then
-            echo "One or more commit messages do not follow Conventional Commits"
-            exit 1
-          fi
+            const invalid = commits
+              .map(c => c.commit.message.split("\n")[0])
+              .filter(msg => !pattern.test(msg));
+
+            if (invalid.length) {
+              core.setFailed(
+                `Invalid commit message(s):\n- ${invalid.join("\n- ")}`
+              );
+            } else {
+              core.info("All commit messages follow Conventional Commits.");
+            }
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-type-labeler.yml
+++ b/.github/workflows/pr-type-labeler.yml
@@ -1,0 +1,73 @@
+name: PR Type Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-by-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR by Conventional title type
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+            const m = title.match(/^(feat|fix|docs|refactor|test|ci|chore)(\([^)]+\))?:\s+/);
+            if (!m) {
+              core.info(`No conventional type prefix found in title: ${title}`);
+              return;
+            }
+
+            const type = m[1];
+            const repo = context.repo;
+            const labelNames = ["feat", "fix", "docs", "refactor", "test", "ci", "chore", "breaking"];
+            const colorMap = {
+              feat: "0e8a16",
+              fix: "d73a4a",
+              docs: "0075ca",
+              refactor: "5319e7",
+              test: "fbca04",
+              ci: "1d76db",
+              chore: "cfd3d7",
+              breaking: "b60205"
+            };
+
+            for (const name of labelNames) {
+              try {
+                await github.rest.issues.getLabel({ ...repo, name });
+              } catch {
+                await github.rest.issues.createLabel({
+                  ...repo,
+                  name,
+                  color: colorMap[name],
+                  description: `PR type: ${name}`
+                });
+              }
+            }
+
+            const current = pr.labels.map(l => l.name);
+            const remove = current.filter(l => labelNames.includes(l) && l !== type);
+            for (const name of remove) {
+              await github.rest.issues.removeLabel({
+                ...repo,
+                issue_number: pr.number,
+                name
+              }).catch(() => {});
+            }
+
+            if (!current.includes(type)) {
+              await github.rest.issues.addLabels({
+                ...repo,
+                issue_number: pr.number,
+                labels: [type]
+              });
+            }
+
+            core.info(`Applied type label '${type}' from title.`);

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,10 +1,9 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ Thank you for considering contributing to the Tupa project.
 2. Update/add relevant documentation.
 3. Run local checks before opening the PR.
 4. Open the PR with context, motivation, and scope.
-5. Wait for review.
+5. Use a Conventional Commits style title in the PR.
+6. Wait for review.
 
 ## Commit message convention
 
@@ -47,6 +48,11 @@ Examples:
 - `feat(parser): support typed pipeline attributes`
 - `fix(typecheck): reject now() in deterministic pipelines`
 - `docs(guides): add local CI usage section`
+
+Rules:
+
+- Generic messages like `ci:` or `docs:` without summary are rejected in CI.
+- PR titles must follow the same Conventional pattern.
 
 ## Local tests
 


### PR DESCRIPTION
Why:
- enforce PR title and commit message conventions
- automate release notes by type

What:
- add blocking checks for PR title and commit messages
- update CONTRIBUTING and PR template
- add PR type labeler and release drafter workflows

Validation:
- workflow syntax reviewed and pushed for PR checks
