### PR TITLE
chore: define release cadence and add code owners

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+  schedule:
+    - cron: "0 13 * * 4"
 
 permissions:
   contents: write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners
+* @marciopaiva
+
+# Governance and process-critical files
+/.github/workflows/* @marciopaiva
+/.github/release-drafter.yml @marciopaiva
+/.github/PULL_REQUEST_TEMPLATE.md @marciopaiva
+/CONTRIBUTING.md @marciopaiva
+/CODEOWNERS @marciopaiva

--- a/docs/en/releases/release_guide.md
+++ b/docs/en/releases/release_guide.md
@@ -4,25 +4,32 @@
 
 This document describes the release process with clear, repeatable steps.
 
+## Release cadence
+
+- Weekly cadence: every Thursday.
+- A release draft is automatically refreshed by GitHub Actions every Thursday at 13:00 UTC.
+- The draft is also refreshed on every push to `main`.
+
 ## Step-by-Step
 
-1. Update [CHANGELOG](changelog.md) and the documentation set.
-2. Run the test suite:
+1. Review the current GitHub Release Draft.
+2. Update [CHANGELOG](changelog.md) and the documentation set.
+3. Run local validation:
 
 ```bash
-cargo test
+./scripts/ci-local.sh
 ```
 
-1. Verify main examples in `examples/` and bilingual docs.
-2. Confirm CI is green.
-3. Create the tag and publish:
+4. Confirm all required CI checks are green on `main`.
+5. Verify main examples in `examples/` and bilingual docs.
+6. Create the tag and publish:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-1. Create the GitHub release with CHANGELOG notes.
+7. Create the GitHub release using the generated draft notes.
 
 ## Tips
 


### PR DESCRIPTION
Why:
- establish a predictable weekly release routine with release draft automation
- protect workflow and governance files with code ownership

What:
- schedule release-drafter weekly on Thursdays
- update release guide with cadence and practical release flow
- add CODEOWNERS for workflow and governance-critical files

Validation:
- ./scripts/ci-local.sh
