### PR TITLE
chore: add backport flow and release checklist

### DIFF
--- a/.github/workflows/backport-label-check.yml
+++ b/.github/workflows/backport-label-check.yml
@@ -1,0 +1,79 @@
+name: Backport Label Check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  validate-backport-labels:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate backport label format
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            const backport = labels.filter(l => l.startsWith('backport-'));
+            const valid = /^backport-\d+\.\d+$/;
+
+            const invalid = backport.filter(l => !valid.test(l));
+            if (invalid.length) {
+              const body = [
+                'Invalid backport label format detected:',
+                ...invalid.map(x => `- ${x}`),
+                '',
+                'Use format: `backport-X.Y` (example: `backport-0.8`).'
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }
+
+  open-backport-tracking-issue:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open tracking issue for backports
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            const backports = labels.filter(l => /^backport-\d+\.\d+$/.test(l));
+            if (!backports.length) {
+              core.info('No valid backport labels found.');
+              return;
+            }
+
+            const title = `Backport required: PR #${pr.number}`;
+            const body = [
+              `Source PR: #${pr.number}`,
+              `Title: ${pr.title}`,
+              '',
+              'Target branches:',
+              ...backports.map(l => `- ${l.replace('backport-', 'release/')} (from label ${l})`),
+              '',
+              'Checklist:',
+              '- [ ] Cherry-pick commits to target branch(es)',
+              '- [ ] Open backport PR(s)',
+              '- [ ] Link backport PR(s) here',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['chore']
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,14 @@ Optional strict link check:
 CI_LOCAL_STRICT_LINKS=1 ./scripts/ci-local.sh
 ```
 
+## Backport labels
+
+If a merged PR must be backported, add labels using this format:
+
+- `backport-X.Y` (example: `backport-0.8`)
+
+The repository workflow validates this format and opens a tracking issue after merge.
+
 ## Documentation style
 
 - Clear, direct English.

--- a/docs/en/releases/release_cut_checklist.md
+++ b/docs/en/releases/release_cut_checklist.md
@@ -1,0 +1,23 @@
+# Release Cut Checklist
+
+Use this checklist when cutting a new release tag.
+
+## Before tag
+
+- [ ] Release Draft is up-to-date and grouped by labels.
+- [ ] CHANGELOG was updated from the draft.
+- [ ] Required checks are green on `main`.
+- [ ] Local validation passed: `./scripts/ci-local.sh`.
+- [ ] No open blockers in high-priority issues.
+
+## Tag and publish
+
+- [ ] Tag created: `vX.Y.Z`.
+- [ ] Tag pushed to origin.
+- [ ] GitHub Release created from draft.
+
+## After release
+
+- [ ] Announce release in team channels.
+- [ ] Open follow-up issues for deferred items.
+- [ ] Confirm next milestone scope.

--- a/docs/en/releases/release_guide.md
+++ b/docs/en/releases/release_guide.md
@@ -10,26 +10,37 @@ This document describes the release process with clear, repeatable steps.
 - A release draft is automatically refreshed by GitHub Actions every Thursday at 13:00 UTC.
 - The draft is also refreshed on every push to `main`.
 
+## Changelog source of truth
+
+- GitHub Release Draft is the source of truth for release notes composition.
+- PR labels (`feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `breaking`) drive section grouping.
+- Before tagging, reconcile draft notes with [CHANGELOG](changelog.md).
+
 ## Step-by-Step
 
 1. Review the current GitHub Release Draft.
-2. Update [CHANGELOG](changelog.md) and the documentation set.
-3. Run local validation:
+2. Review merged PR labels and fix mislabeled items (if any).
+3. Update [CHANGELOG](changelog.md) from the draft notes.
+4. Run local validation:
 
 ```bash
 ./scripts/ci-local.sh
 ```
 
-4. Confirm all required CI checks are green on `main`.
-5. Verify main examples in `examples/` and bilingual docs.
-6. Create the tag and publish:
+5. Confirm all required CI checks are green on `main`.
+6. Verify main examples in `examples/` and bilingual docs.
+7. Create the tag and publish:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-7. Create the GitHub release using the generated draft notes.
+8. Create the GitHub release using the generated draft notes.
+
+## Quick checklist
+
+See [Release Cut Checklist](release_cut_checklist.md).
 
 ## Tips
 


### PR DESCRIPTION
Why:
- formalize backport handling for maintenance branches
- make release execution repeatable with a short checklist

What:
- add workflow to validate backport labels and open tracking issue on merge
- document backport label format in CONTRIBUTING
- add release cut checklist and update release guide

Validation:
- ./scripts/ci-local.sh
