### PR TITLE
docs(i18n): sync releases and add docs parity checks

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -9,12 +9,14 @@ on:
       - ".markdownlint.json"
       - ".markdownlintignore"
       - ".github/workflows/docs-lint.yml"
+      - "scripts/docs-parity-check.sh"
   pull_request:
     paths:
       - "**/*.md"
       - ".markdownlint.json"
       - ".markdownlintignore"
       - ".github/workflows/docs-lint.yml"
+      - "scripts/docs-parity-check.sh"
 
 jobs:
   markdownlint:
@@ -33,6 +35,15 @@ jobs:
 
       - name: Run markdownlint
         run: markdownlint "**/*.md"
+
+  docs-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docs parity check
+        run: ./scripts/docs-parity-check.sh
 
   link-check:
     runs-on: ubuntu-latest

--- a/docs/en/releases/changelog.md
+++ b/docs/en/releases/changelog.md
@@ -1,36 +1,51 @@
-
 # Changelog
 
 ## Purpose
 
 This document records relevant changes per version.
 
-## 0.8.0 (2026-03-04)
+## 0.8.0 (2026-03-05)
 
 - Release theme: controlled, auditable Python integration for production pipelines.
-- Guiding principle: "Integrate without losing governance — every Python call is traced, validated, and auditable."
-- Scope: PyTorch/TensorFlow orchestration via audited adapters.
-- Focus: execution tracing, validation hooks, and audit log schema for Python calls.
+- Guiding principle: "Integrate without losing governance - every Python call is traced, validated, and auditable."
 
-### Added
+### Delivered Scope
 
-- **Python Interoperability (`tupa-pyffi`)**:
-  - Safe bridge for invoking Python modules (e.g., PyTorch, TensorFlow).
-  - `py:module.func` step syntax for direct integration.
-- **Runtime Resilience**:
-  - **Circuit Breaker**: Prevents cascading failures with configurable thresholds and reset timeouts.
-  - **Async Support**: Native `async/await` execution for I/O-bound steps.
-- **Backtesting Engine**:
-  - Historical simulation with PnL tracking and risk constraint evaluation.
-  - Detailed audit logs for every trade and risk block.
-- **Structured Audit Logging**:
-  - JSON-based structured logs via `tracing` crate for compliance.
-- **Validation**:
-  - **Tensor Shapes**: Automatic schema validation for tensor inputs/outputs (e.g., `[28, 28]`).
-  - **Pipeline Attributes**: Support for `@deterministic(seed=...)` and `@external` declarations.
-- **Parser Improvements**:
-  - Fixes for match arm syntax (`=>`) and function return types (`->`).
-  - Enhanced error recovery and span tracking.
+- Python interoperability (`tupa-pyffi`) for safe invocation of `py:module.func` steps.
+- Runtime resilience with circuit breaker and async/await support.
+- Backtesting flow with PnL/risk evaluation and structured audit logging.
+- Validation improvements for tensor shapes, pipeline attributes, and parser/typechecker robustness.
+
+### Engineering and CI Completed
+
+- CI now enforces PR title convention (`type(scope): subject`) and commit message convention.
+- PR auto-labeling by change type (`feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `breaking`).
+- Release drafter enabled with automatic categorization.
+- Branch protection on `main` hardened:
+  - required status checks (`pr-title-convention`, `commit-message-convention`, `lint`, `test`)
+  - strict up-to-date branch requirement
+  - required conversation resolution
+  - required CODEOWNERS review and 1 approval
+  - stale review dismissal enabled
+- CODEOWNERS added for governance and workflow-critical files.
+- Backport governance implemented:
+  - `backport-X.Y` label validation workflow
+  - automatic tracking issue creation on merged PRs with backport labels
+- Release operations documented with `release_guide.md` and `release_cut_checklist.md`.
+- Local validation standardized through `scripts/ci-local.sh` (code + docs/link lint).
+
+### Validation Snapshot (workspace)
+
+- Local full check executed on 2026-03-05: `./scripts/ci-local.sh`.
+- Result: pass (`fmt`, `clippy`, `test`, `markdownlint`, `lychee`).
+- Working tree status during validation: clean on `main`.
+
+### Technical Debt
+
+- Commit convention enforcement still depends on PR context; direct pushes to protected branches remain policy-dependent and should stay blocked by branch protection.
+- Docs quality gates are strong in CI, but multilingual changelog parity (`en`, `es`, `pt-br`) is not yet automated.
+- Backport workflow creates tracking issues, but backport cherry-pick automation is not implemented yet.
+- Performance goals are documented, but there is no CI trend dashboard storing historical latency and throughput metrics.
 
 ## 0.7.0 (2026-02-20)
 
@@ -62,13 +77,13 @@ This document records relevant changes per version.
     - `tupa codegen --format=llvm examples/pipeline/minimal.tp`
     - `tupa run --pipeline=FraudDetection --input examples/pipeline/inputs/tx.json`
   - Optional: use `hyperfine` to benchmark:
-    - `hyperfine --warmup 3 'tupa codegen --format=llvm examples/pipeline/minimal.tp' 'tupa run --pipeline=FraudDetection --input examples/pipeline/inputs/tx.json'`
+    - `hyperfine --warmup 3 "tupa codegen --format=llvm examples/pipeline/minimal.tp" "tupa run --pipeline=FraudDetection --input examples/pipeline/inputs/tx.json"`
   - Conditions: Linux, Rust stable (>=1.75), release builds preferred when applicable
-- Hardware & conditions:
+- Hardware and conditions:
   - Linux x86_64, Rust stable, local dev machine, cold run
 - Test reference (prints timing):
   - `cargo test -p tupa-cli perf -- --nocapture`
-  - Observed locally: `codegen fraud_complete ≈ 1ms`, `run fraud_complete ≈ 3ms` (non-CI, illustrative)
+  - Observed locally: `codegen fraud_complete ~= 1ms`, `run fraud_complete ~= 3ms` (non-CI, illustrative)
 
 ## 0.6.0 (2026-02-13)
 

--- a/docs/es/features/trading_support.md
+++ b/docs/es/features/trading_support.md
@@ -1,0 +1,64 @@
+﻿# Soporte para Bots de Trading en Tupã
+
+Este documento detalla las funcionalidades implementadas en Tupã Runtime (v0.8.0) para soportar aplicaciones de trading algorítmico como `ViperTrade`.
+
+## Resumen
+
+El lenguaje y runtime de Tupã fueron ampliados para soportar operaciones financieras críticas, garantizando seguridad, resiliencia y auditabilidad.
+
+## Funcionalidades Clave
+
+### 1. Motor de Backtesting
+
+La función `run_backtest` ofrece un entorno nativo de simulación para estrategias de trading.
+
+- **Propósito**: Validar la lógica de estrategia contra datos históricos antes del despliegue en vivo.
+- **Mecanismo**:
+  - Itera sobre un dataset de velas/ticks históricos.
+  - Ejecuta el pipeline para cada paso temporal.
+  - Evalúa restricciones de riesgo (ej. `MaxDrawdown`, `PositionSize`).
+  - Rastrea PnL de portafolio (Profit and Loss) con base en señales `BUY`/`SELL` y precios `close`.
+- **Auditoría**: Cada operación y acción bloqueada queda registrada con una traza de auditoría estructurada.
+
+### 2. Circuit Breaker
+
+Patrón de resiliencia para evitar fallas en cascada durante volatilidad de mercado o caídas de API.
+
+- **Configuración**:
+  - `failure_threshold`: Número de errores consecutivos permitidos (ej. 3).
+  - `reset_timeout`: Tiempo de espera antes de volver a probar la conexión (ej. 30s).
+- **Comportamiento**:
+  - **Closed**: Operación normal.
+  - **Open**: Bloquea la ejecución inmediatamente al alcanzar el umbral.
+  - **Half-Open**: Permite una única solicitud de prueba para verificar recuperación.
+
+### 3. Integración con IA en Python (`tupa-pyffi`)
+
+Integración transparente con modelos ML en Python (PyTorch/TensorFlow) para generación de señales.
+
+- **Sintaxis**: Pasos definidos como `py:module.func` (ej. `py:viper_model.predict`).
+- **Seguridad**: Inputs y outputs se validan contra esquemas estrictos (ej. shapes de tensores `[1, 60, 4]`).
+- **Rendimiento**: Transferencia de datos zero-copy (cuando es posible) vía FFI.
+
+### 4. Logging de Auditoría Estructurado
+
+Logging listo para cumplimiento utilizando `tracing`.
+
+- **Formato**: Logs estructurados en JSON.
+- **Eventos**:
+  - `pipeline_start` / `pipeline_complete`
+  - `trade_executed` (con precio, tipo e índice)
+  - `trade_blocked_by_risk` (cuando fallan restricciones)
+  - `circuit_breaker_tripped`
+
+## Ejemplo de Uso
+
+```rust
+// Configurando el runtime para un bot de trading
+let runtime = Runtime::new();
+runtime.configure_circuit_breaker(3, Duration::from_secs(10));
+
+// Ejecutando un backtest
+let result = runtime.run_backtest(&plan, historical_data).await?;
+println!("PnL final: {}", result["final_pnl"]);
+```

--- a/docs/es/reference/spec.md
+++ b/docs/es/reference/spec.md
@@ -1,0 +1,1074 @@
+# Especificación del Lenguaje Tupã v0.1
+
+> **Fuerza ancestral, código moderno**  
+> Lenguaje brasileño para sistemas críticos e IA en evolución
+
+![Specification Status](https://img.shields.io/badge/status-draft-orange)
+![License](https://img.shields.io/badge/license-CC--BY--SA%204.0-ff69b4)
+
+## Propósito
+
+Definir la especificación formal del lenguaje Tupã, incluyendo gramática, reglas de tipo y semántica.
+
+## Índice
+
+- [1. Filosofía y objetivos de diseño](#1-filosofía-y-objetivos-de-diseño)
+- [2. Estructura léxica](#2-estructura-léxica)
+- [3. Sistema de tipos](#3-sistema-de-tipos)
+- [4. Expressões](#4-expressões)
+- [5. Instrucciones](#5-instrucciones)
+- [6. Semántica numérica (Normativa)](#6-semántica-numérica-normativa)
+- [6. Concurrencia](#6-concurrencia)
+- [7. Módulos y FFI](#7-módulos-y-ffi)
+- [8. Gramática EBNF completa (Normativa)](#8-gramática-ebnf-completa-normativa)
+- [9. Semántica y notas de implementación](#9-semántica-y-notas-de-implementación)
+- [10. Conversiones de tipos (Normativa)](#10-conversiones-de-tipos-normativa)
+- [10. Exemplos validados](#10-exemplos-validados)
+- [11. Diagnósticos (Normativa)](#11-diagnósticos-normativa)
+- [12. Política de versionado](#12-política-de-versionado)
+- [13. Referencias e influencias](#13-referencias-e-influencias)
+
+---
+
+## 1. Filosofía y objetivos de diseño
+
+### 1.1 Principios centrales
+
+1. **Rendimiento predecible**: zero alocações ocultas; custo de ejecución visível no código-fonte
+2. **Diferenciabilidad nativa**: qualquer expressão pura é automaticamente diferenciável via operador `∇`
+3. **Alineamiento vía tipos**: restrições éticas verificadas em tempo de compilación, não em tempo de ejecución
+4. **Esparsidad declarativa**: densidade de dados faz parte do tipo, não de uma otimização pós-processamento
+
+### 1.2 Público objetivo
+
+- Investigadores de IA que precisam de rendimiento e segurança formal
+- Ingenieros de sistemas críticos (fintech, saúde, infraestrutura)
+- Desenvolvedores que valorizam produtividade sem sacrificar controle
+
+### 1.3 No objetivos
+
+- Reemplazar Python para scripts rápidos
+- Ser 100% compatible com a sintaxe de Rust/Python
+- Soportar programación imperativa no estructurada
+
+### 1.4 Convenciones del documento
+
+- **Normativo**: seções com gramática EBNF, regras de tipo e semântica são obrigatórias.
+- **Informativo**: exemplos, notas e comentários servem como orientação.
+
+### 1.5 Alcance del MVP (núcleo)
+
+- Lexer + parser para funciones, `let`, `if`, `match`, chamadas e literais.
+- Verificador de tipos para tipos primitivos e tuplas simples.
+- Semântica do `∇` limitada a funciones puras.
+- Geração de código para expressões aritméticas básicas.
+
+---
+
+## 2. Estructura léxica
+
+### 2.1 Codificación de caracteres
+
+- UTF-8 obrigatório
+- Identificadores suportam letras Unicode (`\p{L}`) + `_`
+- Palabras clave são apenas ASCII (case-sensitive)
+
+### 2.2 Comentarios
+
+```tupa
+// Comentario de línea única
+
+/* Comentario
+   de múltiples líneas */
+```
+
+### 2.3 Identificadores
+
+```ebnf
+identifier = letter { letter | digit | "_" } ;
+letter     = "a".."z" | "A".."Z" | "\u{0080}".."\u{10FFFF}" ;
+digit      = "0".."9" ;
+```
+
+**Normalización Unicode (Normativo)**:
+
+- Identificadores são comparados após normalização NFC.
+- O compilador deve rejeitar identificadores que mudam após a normalização (para evitar confusão visual).
+
+**Ejemplos válidos**: `x`, `_temp`, `ação`, `π_value`  
+**Ejemplos inválidos**: `1var`, `@name`, `fn` (palabra clave)
+
+### 2.4 Palabras clave
+
+```text
+fn let if else match while for in return async spawn await
+pipeline step
+true false null i64 f64 f32 f16 bool string tensor option result
+safe unsafe extern import export
+```
+
+### 2.5 Literales
+
+```ebnf
+integer_literal = digit { digit } ;
+float_literal   = digit { digit } "." digit { digit } [ ("e" | "E") ["+" | "-"] digit { digit } ] ;
+string_literal  = '"' { unicode_char | escape_sequence } '"' ;
+escape_sequence = "\\" ("n" | "t" | '"' | "\\" | "u{" hex_digit {1,6} "}") ;
+hex_digit       = digit | "a".."f" | "A".."F" ;
+tensor_literal  = "[" expression { "," expression } "]" ;
+```
+
+**Exemplos**:
+
+```tupa
+42          // integer_literal
+3.14        // float_literal
+1.5e-3      // notación científica
+"Olá 🌩️"   // string con Unicode
+"newline\n" // secuencia de escape
+[1, 2, 3]   // tensor_literal
+```
+
+---
+
+## 3. Sistema de tipos
+
+### 3.1 Tipos primitivos
+
+| Tipo | Descrição | Tamanho | Exemplo |
+| --- | --- | --- | --- |
+| `i64` | Inteiro com sinal | 64-bit | `42` |
+| `f64` | IEEE 754 double | 64-bit | `3.14` |
+| `f32` | IEEE 754 float | 32-bit | `1.0f32` |
+| `f16` | Meia precisão | 16-bit | `0.5f16` |
+| `bool` | Booleano | 1-bit | `true` |
+| `string` | UTF-8 imutável | dinâmico | `"Tupã"` |
+
+### 3.2 Tipos compuestos
+
+#### 3.2.1 Tuplas
+
+```ebnf
+tuple_type = "(" type { "," type } [","] ")" ;
+```
+
+```tupa
+let pair: (i64, string) = (42, "answer")
+let first = pair.0  // 42
+```
+
+#### 3.2.2 Tipos de función (Normativo)
+
+```ebnf
+func_type = "fn" "(" [ type { "," type } ] ")" "->" type ;
+```
+
+```tupa
+let f: fn(i64, i64) -> i64 = add
+let g: fn() -> bool = is_ready
+// Función anónima (lambda)
+let inc: fn(i64) -> i64 = |x| x + 1
+// Función como valor
+let apply: fn(fn(i64)->i64, i64) -> i64 = |f, x| f(x)
+let r = apply(inc, 10) // r = 11
+// Função com print e concatenação de string
+fn hello(name: string) {
+  print("Hola, " + name)
+}
+hello("Tupã")
+```
+
+**Comparação:**
+
+| Tupã | Python | Rust |
+| --- | --- | --- |
+| `let inc: fn(i64)->i64 = \|x\| x+1` | `inc = lambda x: x+1` | `let inc = \|x: i64\| x+1;` |
+| `print("Hola, " + name)` | `print("Hola, " + name)` | `println!("Hola, {}", name);` |
+
+Veja mais exemplos no [Guia de exemplos](../guides/examples_guide.md) e no [examples/README.md](../../examples/README.md).
+
+#### 3.2.3 Tipos enum (genéricos)
+
+```ebnf
+enum_decl = "enum" identifier [ "<" identifier { "," identifier } ">" ] "{" enum_variant { "," enum_variant } [ "," ] "}" ;
+enum_variant = identifier [ "(" type { "," type } [ "," ] ")" ] ;
+enum_type = identifier [ "<" type { "," type } ">" ] ;
+```
+
+```tupa
+enum Result<T, E> {
+  Ok,
+  Err
+}
+
+fn use_result(r: Result<Safe<f64, !nan>, string>) {
+  print("ok")
+}
+```
+
+#### 3.2.4 Option / Result (tratamento de errors)
+
+```ebnf
+option_type = "Option" "<" type ">" ;
+result_type = "Result" "<" type "," type ">" ;
+```
+
+```tupa
+fn divide(a: f64, b: f64): Result<f64, string> {
+  if b == 0.0 {
+    return Err("Division by zero")
+  }
+  return Ok(a / b)
+}
+```
+
+#### 3.2.5 Tensores (IA de primeira classe)
+
+```ebnf
+tensor_type = "Tensor" "<" 
+              type "," 
+              "shape" "=" "[" dimension { "," dimension } "]" 
+              [ "," "density" "=" float_literal ] 
+            ">" ;
+dimension   = integer_literal | "..." ;  // "..." = dimensão dinâmica
+```
+
+```tupa
+// Tensor denso 28x28 (MNIST)
+let image: Tensor<f32, shape=[28, 28]> = load("digit.tp")
+
+// Tensor esparso 90% (recomendado para LLMs)
+let weights: Tensor<f16, shape=[4096, 4096], density=0.1> = load("llama3.tp")
+```
+
+#### 3.2.6 Tipos de alinhamento (restrições éticas)
+
+```ebnf
+safe_type = "Safe" "<" type "," constraint_list ">" ;
+constraint_list = "!" identifier { "," "!" identifier } ;
+```
+
+```tupa
+// Texto que não pode conter discurso de ódio
+let summary: Safe<string, !hate_speech> = summarize(article)
+
+// Número que não pode ser NaN/Inf (crítico para treinamento estável)
+let loss: Safe<f64, !nan, !inf> = compute_loss(predictions, targets)
+```
+
+Exemplo com propagação via enum:
+
+```tupa
+enum Reason {
+  Misinformation
+}
+
+enum LLMResponse<T> {
+  Safe(T),
+  Flagged(T, Reason),
+  Blocked(Reason)
+}
+
+fn classify(text: string): LLMResponse<Safe<string, !misinformation>> {
+  if is_misinformation(text) {
+    return Flagged(text, Misinformation())
+  }
+  return Safe(text)
+}
+```
+
+Exemplo com correspondência de padrões:
+
+```tupa
+fn handle(response: LLMResponse<Safe<string, !misinformation>>) {
+  match response {
+    Safe(text) => publish(text),
+    Flagged(text, reason) => review(text, reason),
+    Blocked(reason) => reject(reason),
+  }
+}
+```
+
+> **Nota**: Restrições são verificadas via:
+>
+> - Provas formais (para propriedades matemáticas)
+> - Scores RLHF (para conteúdo gerado por LLMs)
+> - Alternativa de guarda em tempo de ejecución (se não for possível provar em tempo de compilación)
+
+**Semântica**:
+
+- Se o compilador **provar** a restrição, o tipo `Safe<T, !c>` é válido.
+- Se **não conseguir provar**, é error em tempo de compilación (com sugestão de correção).
+- `unsafe { ... }` pode ser usado para assumir responsabilidade explícita.
+
+**Implementação atual (compilador)**:
+
+- `!nan` e `!inf` são aceitos apenas para base `f64`.
+- `!hate_speech` e `!misinformation` são aceitos apenas para base `string`.
+- A prova é feita apenas com literais `f64` e expressões constantes (por exemplo, `1.0`, `-1.0`, `1.0 + 2.0`, `1.0 / 0.0`).
+- Para restrições de `string`, o compilador só aceita valores já comprovados como `Safe<string, ...>` (propagação de variáveis/retornos).
+- Se a prova não for possível, o compilador reporta um error de restrição não comprovada.
+
+##### 3.2.6.1 Resolução de restrições (Normativa)
+
+Para cada restrição `!c` em `Safe<T, !c>`:
+
+| Restrição | Requisito do solucionador | Alternativa |
+| --- | --- | --- |
+| `!nan` | Análise de intervalos prova `x ∈ [-∞, +∞] \ {NaN}` | `@assume(!nan)` com aviso |
+| `!inf` | Limites estáticos provam `abs(x) < 1.7976931348623157e308` | `@assume(!inf)` com aviso |
+| `!hate_speech` | Scorer RLHF ≥ 0.95 no dataset definido | ❌ Não permitido |
+| `!misinformation` | Scorer RLHF ≥ 0.95 no dataset definido | ❌ Não permitido |
+
+---
+
+### 3.3 Tipos de array (Normativo)
+
+```ebnf
+array_type = "[" type ";" integer_literal "]" ;  // tamanho fixo
+slice_type = "[" type "]" ;                      // tamanho dinâmico
+```
+
+```tupa
+let fixed: [i64; 5] = [1, 2, 3, 4, 5]
+let dynamic: [i64] = vec![1, 2, 3]
+```
+
+**Semântica (Normativa)**:
+
+- `[T; N]` é alocado na pilha quando possível.
+- `[T]` é alocado no heap e é mutável apenas se referenciado por `mut`.
+- Literales `[a, b, c]` inferem `[T; N]` quando `N` é conhecido.
+
+---
+
+## 4. Expressões
+
+### 4.0 Precedência de operadores (maior → menor)
+
+| Precedência | Operadores |
+| --- | --- |
+| 1 | `()` `.` chamada de función |
+| 2 | `∇` unário |
+| 3 | `!` `-` unário |
+| 4 | `**` |
+| 5 | `*` `/` |
+| 6 | `+` `-` |
+| 7 | `<` `<=` `>` `>=` |
+| 8 | `==` `!=` |
+| 9 | `&&` |
+| 10 | `\|\|` |
+
+### 4.1 Regras de avaliação (Normativa)
+
+- `if` avalia apenas o ramo selecionado.
+- `a && b` usa curto-circuito: `b` é avaliado apenas se `a` for `true`.
+- `a || b` usa curto-circuito: `b` é avaliado apenas se `a` for `false`.
+- `match` avalia apenas o corpo do primeiro padrão compatible.
+
+### 4.1 Gramática completa
+
+```ebnf
+expression        = assignment
+                  | conditional
+                  | match_expr
+                  | binary_expr
+                  | unary_expr
+                  | primary_expr ;
+
+assignment        = identifier "=" expression ;
+
+conditional       = "if" expression block [ "else" ( block | conditional ) ] ;
+
+match_expr        = "match" expression "{" { match_arm } "}" ;
+match_arm         = pattern ["if" guard] "=>" expression [","] ;
+guard             = expression ;
+pattern           = "_" 
+                  | literal 
+                  | identifier 
+                  | tuple_pattern 
+                  | constructor_pattern ;
+tuple_pattern     = "(" pattern { "," pattern } [","] ")" ;
+constructor_pattern = identifier "(" pattern { "," pattern } [","] ")" ;
+
+binary_expr       = unary_expr { binary_op unary_expr } ;
+binary_op         = "||" | "&&" | "==" | "!=" | "<" | "<=" | ">" | ">=" 
+                  | "+" | "-" | "*" | "/" | "**" ;  // ** = exponenciação
+
+unary_expr        = [ unary_op ] primary_expr ;
+unary_op          = "!" | "-" | "∇" ;  // ∇ = operador de gradiente
+
+primary_expr      = literal
+                  | identifier
+                  | "(" expression ")"
+                  | identifier "(" [ argument_list ] ")"
+                  | identifier "." field_access
+                  | "await" expression ;
+
+argument_list     = expression { "," expression } ;
+field_access      = identifier | integer_literal ;
+literal           = integer_literal | float_literal | string_literal | "true" | "false" | "null" ;
+```
+
+### 4.2 Expressões-chave
+
+#### 4.2.1 Operador de gradiente (`∇`)
+
+```tupa
+// Função pura → derivada simbólica gerada pelo compilador
+fn square(x: f64): f64 { x * x }
+
+let grad_at_3 = ∇square(3.0)  // → 6.0 (derivada: 2*x)
+
+// Derivada parcial para múltiplos parámetros
+fn mse(pred: f64, target: f64): f64 {
+  let diff = pred - target
+  return diff * diff
+}
+
+let (d_pred, d_target) = ∇mse(0.8, 1.0)  // → (-0.4, 0.4)
+```
+
+**Tipo de retorno**:
+
+- Para `f: (T1, ..., Tn) -> R`, `∇f(args)` retorna `(dT1, ..., dTn)`.
+- Para `n = 1`, o retorno é um escalar `dT1`.
+- O valor de `f(args)` pode ser obtido chamando `f(args)` separadamente.
+
+##### Pureza formal (Normativa)
+
+Uma función `f` é **pura** se e somente se:
+
+1. Não chama funciones com o atributo `@side_effects(...)`.
+2. Não acessa nem modifica variáveis mutáveis não locais (`static mut`, globais).
+3. Não realiza operações de E/S (`print`, `file.read`, `http.get`).
+4. Não contém não determinismo (`rand()`, `time.now()`, `thread_id()`).
+5. Todas as funciones chamadas por `f` são puras (recursão de pureza).
+
+> **Regra de pureza**: `∇` só funciona em expressões *puras* (sem efeitos colaterais). O compilador rejeita:
+>
+> ```tupa
+> fn impure(x: f64): f64 {
+>     print(x)  // efeito colateral!
+>     return x * 2
+> }
+> let g = ∇impure(3.0)  // ❌ Erro: a función não é pura
+> ```
+
+#### 4.2.2 Correspondência de padrões
+
+```tupa
+match http_status {
+  200 => "OK",
+  404 => "Não encontrado",
+  code if code >= 500 => f"Erro do servidor {code}",
+  _ => "Desconhecido"
+}
+```
+
+#### 4.2.3 Interpolação de strings
+
+```tupa
+let name = "Tupã"
+print(f"Hola, {name}!")  // → "Hola, Tupã!"
+```
+
+---
+
+## 5. Instrucciones
+
+### 5.1 Gramática
+
+```ebnf
+statement         = declaration
+                  | expression ";"
+                  | block
+                  | control_flow ;
+
+declaration       = "let" [ "mut" ] identifier [ ":" type ] "=" expression ";"
+                  | function_decl
+                  | enum_decl ;
+
+function_decl     = [ attribute_list ] "fn" identifier 
+                  "(" [ parameter_list ] ")" 
+                  [ ":" type ] 
+                  block ;
+
+enum_decl         = "enum" identifier [ "<" identifier { "," identifier } ">" ] 
+                  "{" enum_variant { "," enum_variant } [ "," ] "}" ;
+enum_variant      = identifier [ "(" type { "," type } [ "," ] ")" ] ;
+
+attribute_list    = "@" identifier [ "(" attribute_args ")" ] 
+                  { "@" identifier [ "(" attribute_args ")" ] } ;
+attribute_args    = identifier "=" literal { "," identifier "=" literal } ;
+
+parameter_list    = parameter { "," parameter } ;
+parameter         = identifier ":" type ;
+
+block             = "{" { statement } "}" ;
+
+control_flow      = "return" [ expression ] ";"
+                  | "while" expression block
+                  | "for" identifier "in" range_expr block ;
+
+range_expr        = expression ".." expression ;  // fim exclusivo
+```
+
+### 5.2 Vinculação de variáveis
+
+```tupa
+// Inferência de tipos
+let x = 42          // x: i64
+let pi = 3.14       // pi: f64
+
+// Tipo explícito (recomendado para APIs públicas)
+let name: string = "Tupã"
+
+// Mutabilidade explícita (padrão é imutável)
+let mut counter = 0
+counter = counter + 1  // permitido
+```
+
+### 5.3 Funções
+
+```tupa
+// Função pura (padrão) → automaticamente diferenciável
+fn relu(x: f64): f64 {
+  if x > 0.0 { x } else { 0.0 }
+}
+
+// Função com efeitos colaterais explícitos
+@side_effects(io)
+fn log(message: string) {
+  print(f"[LOG] {message}")
+}
+
+// Função assíncrona
+async fn fetch_user(id: i64): Result<User, string> {
+  let resp = await http.get(f"/api/users/{id}")
+  return parse_user(resp)
+}
+```
+
+### 5.4 Controle de fluxo
+
+```tupa
+// if como expressão
+let status = if temp > 100 { "crítico" } else { "normal" }
+
+// loop while
+let mut i = 0
+while i < 10 {
+  print(i)
+  i = i + 1
+}
+
+// loop for com range
+for i in 0..10 {
+  print(i)  // 0, 1, 2, ..., 9 (fim exclusivo)
+}
+```
+
+### 5.5 Escopo e sombreado (Normativa)
+
+- A resolução de nomes é léxica, do bloco mais interno ao mais externo.
+- O sombreado é permitido (estilo Rust).
+- Redeclarar o mesmo nome no mesmo escopo é error.
+
+Exemplo:
+
+```tupa
+let x = 10
+fn foo() {
+  let x = 20
+  print(x)  // 20
+}
+```
+
+---
+
+## 6. Semántica numérica (Normativa)
+
+### 6.1 Overflow de inteiro
+
+- Overflow em `i64` gera error em tempo de ejecución (panic).
+- `wrap_add`, `wrap_sub`, `wrap_mul` devem ser usados para overflow intencional.
+
+Exemplo:
+
+```tupa
+let x: i64 = 9223372036854775807
+let y = x.wrap_add(1)
+```
+
+---
+
+## 6. Concurrencia
+
+### 6.1 Criação de tarefas
+
+```ebnf
+spawn_stmt = "spawn" expression ";" ;
+```
+
+```tupa
+spawn async fn worker(id: i64) {
+  let data = await db.query(id)
+  process(data)
+}
+
+// Spawn anônimo
+spawn async {
+  let result = await heavy_computation()
+  send_to_main(result)
+}
+```
+
+### 6.2 Canais
+
+```tupa
+// Criação de canal tipado
+let (tx, rx): (Channel<i64>, Channel<i64>) = channel()
+
+// Envio
+await tx.send(42)
+
+// Recebimento (bloqueante)
+let value = await rx.recv()  // valor: i64
+
+// Recebimento com timeout
+match await rx.recv_timeout(1000) {  // 1000ms
+  Some(v) => print(f"Recebido: {v}"),
+  None => print("Timeout!")
+}
+```
+
+> **Garantia**: Canais são *baseados em ownership*, tornando corridas de dados impossíveis via sistema de tipos.
+
+---
+
+## 7. Módulos y FFI
+
+### 7.1 Módulos
+
+```tupa
+// math.tp
+export fn square(x: f64): f64 { x * x }
+
+// main.tp
+import "math" as math
+
+let result = math.square(5.0)
+```
+
+### 7.2 Interface de función estrangeira (C)
+
+```tupa
+extern "C" {
+  fn malloc(size: i64): *void
+  fn free(ptr: *void)
+}
+
+fn main() {
+  let ptr = unsafe { malloc(1024) }
+  // ... uso ...
+  unsafe { free(ptr) }
+}
+```
+
+**ABI mínimo (Normativa)**:
+
+- Tipos obrigatórios: `usize`, `*const T`, `*mut T`.
+- Inteiros C: `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`.
+- Ponteiros opacos: `*void`.
+- `usize` tem o mesmo tamanho do ponteiro de dados da plataforma.
+- Ponteiros não podem ser desreferenciados fora de `unsafe`.
+
+> **Regra**: `unsafe` exige um bloco explícito, o que ajuda na auditoria.
+
+---
+
+## 8. Gramática EBNF completa (Normativa)
+
+```ebnf
+(* ===== LÉXICO ===== *)
+letter          = "a".."z" | "A".."Z" | "\u{0080}".."\u{10FFFF}" ;
+digit           = "0".."9" ;
+hex_digit       = digit | "a".."f" | "A".."F" ;
+identifier      = letter { letter | digit | "_" } ;
+integer_literal = digit { digit } ;
+float_literal   = digit { digit } "." digit { digit } 
+                  [ ("e" | "E") ["+" | "-"] digit { digit } ] ;
+string_literal  = '"' { ( "\u{0000}".."\u{0021}" | "\u{0023}".."\u{005B}" | "\u{005D}".."\u{10FFFF}" ) 
+                      | escape_sequence } '"' ;
+escape_sequence = "\\" ( "n" | "t" | '"' | "\\" | "u{" hex_digit {1,6} "}" ) ;
+
+(* ===== TIPOS ===== *)
+type            = primitive_type
+                | tuple_type
+                | enum_type
+                | option_type
+                | result_type
+                | tensor_type
+                | safe_type
+                | identifier ;
+
+primitive_type  = "i64" | "f64" | "f32" | "f16" | "bool" | "string" ;
+tuple_type      = "(" type { "," type } [","] ")" ;
+enum_type       = identifier [ "<" type { "," type } ">" ] ;
+option_type     = "Option" "<" type ">" ;
+result_type     = "Result" "<" type "," type ">" ;
+tensor_type     = "Tensor" "<" 
+                    type "," 
+                    "shape" "=" "[" dimension { "," dimension } "]" 
+                    [ "," "density" "=" float_literal ] 
+                  ">" ;
+dimension       = integer_literal | "..." ;
+safe_type       = "Safe" "<" type "," constraint_list ">" ;
+constraint_list = "!" identifier { "," "!" identifier } ;
+
+(* ===== EXPRESSÕES ===== *)
+expression      = assignment
+                | conditional
+                | match_expr
+                | binary_expr
+                | unary_expr
+                | primary_expr ;
+
+assignment      = identifier "=" expression ;
+
+conditional     = "if" expression block [ "else" ( block | conditional ) ] ;
+
+match_expr      = "match" expression "{" { match_arm } "}" ;
+match_arm       = pattern [ "if" expression ] "=>" expression [ "," ] ;
+pattern         = "_" 
+                | literal 
+                | identifier 
+                | tuple_pattern 
+                | constructor_pattern ;
+tuple_pattern   = "(" pattern { "," pattern } [ "," ] ")" ;
+constructor_pattern = identifier "(" pattern { "," pattern } [ "," ] ")" ;
+
+binary_expr     = unary_expr { binary_op unary_expr } ;
+binary_op       = "||" | "&&" | "==" | "!=" | "<" | "<=" | ">" | ">=" 
+                | "+" | "-" | "*" | "/" | "**" ;
+
+unary_expr      = [ unary_op ] primary_expr ;
+unary_op        = "!" | "-" | "∇" ;
+
+primary_expr    = literal
+                | identifier
+                | "(" expression ")"
+                | identifier "(" [ argument_list ] ")"
+                | identifier "." ( identifier | integer_literal )
+                | "await" expression ;
+
+literal         = integer_literal | float_literal | string_literal | "true" | "false" | "null" ;
+tensor_literal  = "[" expression { "," expression } "]" ;
+argument_list   = expression { "," expression } ;
+
+(* ===== INSTRUÇÕES ===== *)
+statement       = declaration
+                | expression ";"
+                | block
+                | control_flow ;
+
+declaration     = "let" [ "mut" ] identifier [ ":" type ] "=" expression ";"
+                | function_decl
+                | enum_decl
+                | pipeline_decl ;
+
+function_decl   = [ attribute_list ] "fn" identifier 
+                  "(" [ parameter_list ] ")" 
+                  [ ":" type ] 
+                  block ;
+
+enum_decl       = "enum" identifier [ "<" identifier { "," identifier } ">" ] 
+                  "{" enum_variant { "," enum_variant } [ "," ] "}" ;
+enum_variant    = identifier [ "(" type { "," type } [ "," ] ")" ] ;
+
+attribute_list  = "@" identifier [ "(" attribute_args ")" ] 
+                  { "@" identifier [ "(" attribute_args ")" ] } ;
+attribute_args  = identifier "=" literal { "," identifier "=" literal } ;
+
+parameter_list  = parameter { "," parameter } ;
+parameter       = identifier ":" type ;
+
+block           = "{" { statement } "}" ;
+
+control_flow    = "return" [ expression ] ";"
+                | "while" expression block
+                | "for" identifier "in" range_expr block ;
+
+range_expr      = expression ".." expression ;
+
+(* ===== NÍVEL SUPERIOR ===== *)
+program         = { import_decl | export_decl | declaration } ;
+import_decl     = "import" string_literal [ "as" identifier ] ";" ;
+export_decl     = "export" ( function_decl | "let" identifier ) ;
+ 
+(* ===== PIPELINES ===== *)
+pipeline_decl   = "pipeline" identifier [ "@" attribute_list ] "{" pipeline_body "}" ;
+pipeline_body   = "input" ":" type "," 
+                  [ "constraints" ":" "[" identifier { "," identifier } "]" "," ]
+                  "steps" ":" "[" step_list "]" [ "," ]
+                  [ "validation" ":" block ] ;
+step_list       = step_decl { "," step_decl } ;
+step_decl       = "step" "(" string_literal ")" "{" expression "}" ;
+```
+
+---
+
+## 9. Semántica y notas de implementación
+
+### 9.1 Pipeline do compilador
+
+```text
+Fonte (.tp) 
+  ↓ [Lexer: nom]
+Tokens 
+  ↓ [Parser: descida recursiva]
+AST 
+  ↓ [Verificador de tipos: Hindley-Milner + solucionador de restrições]
+AST tipada 
+  ↓ [Geração de código: inkwell → LLVM IR]
+LLVM IR 
+  ↓ [Otimizador LLVM (-O3)]
+Binário nativo (ELF/Mach-O/PE)
+```
+
+### 9.2 Estratégia de compilación de gradientes
+
+Para `∇f(x)` quando `f` é pura:
+
+1. O parser marca a función como `#[pure]` (implícito via análise de efeitos)
+2. O typechecker verifica ausência de efeitos colaterais (E/S, mutação global, não determinismo)
+3. A geração de código emite **dois caminhos** em LLVM IR:
+   - Passo direto: código original
+   - Passo reverso: derivadas simbólicas via regras de diferenciação automática (regra da cadeia, regra do produto)
+4. O runtime seleciona o caminho com base no uso de `∇`
+
+Nota: Para funciones puras pequenas (<100 ops), usar diferenciação simbólica sem fita. Para funciones maiores, permitir fallback para diferenciação baseada em fita com um alocador em arena.
+
+**Exemplo de LLVM IR gerado** para `fn square(x: f64): f64 { x * x }`:
+
+```llvm
+; Passo direto
+define double @square(double %x) {
+  %mul = fmul double %x, %x
+  ret double %mul
+}
+
+; Passo reverso (gerado automaticamente)
+define { double, double } @square_grad(double %x) {
+  %mul = fmul double %x, %x        ; direto
+  %grad = fmul double 2.0, %x      ; derivada: 2*x
+  %ret = insertvalue { double, double } undef, double %mul, 0
+  %ret2 = insertvalue { double, double } %ret, double %grad, 1
+  ret { double, double } %ret2
+}
+```
+
+### 9.3 Verificação de tipos de alinhamento
+
+Para `Safe<T, !constraint>`:
+
+- O compilador consulta o **solucionador de restrições** (plugin):
+  - Para `!nan`: análise de intervalos estática + propagação de restrições
+  - Para `!hate_speech`: integração offline com um scorer de RLHF (limiar configurável)
+- Se o solucionador não consegue provar segurança → error em tempo de compilación com sugestão de correção
+- Alternativa explícita: `unsafe { ... }` com auditoria obrigatória via `@audit(required=true)`
+
+### 9.4 Modelo de memória
+
+- **Alocação na pilha** preferida para valores pequenos (< 4KB)
+- **Alocação em arena** para ASTs e estruturas temporárias (zero overhead de GC)
+- **GC de rastreamento opcional** apenas para ciclos de referência (habilitado via atributo `@gc`)
+- **Sem alocações ocultas**: todas as alocações exigem uma chamada explícita a `alloc()`
+
+### 9.5 Diagnósticos (Normativa)
+
+- Erros devem incluir: código, mensagem, localização e sugestão.
+- Formato mínimo: `E####: mensagem (arquivo:linha:coluna)`.
+- Exemplo: `E3002: não foi possível provar a restrição '!nan' em tempo de compilación (main.tp:12:5)`.
+
+**Códigos recomendados**:
+
+- `E1001`: error léxico
+- `E2001`: error de tipo
+- `E3001`: restrição inválida
+- `E3002`: restrição não comprovada
+- `E4001`: uso inválido de `unsafe`
+
+Exemplo:
+`E2001: tipos incompatíveis em atribuição (main.tp:8:12)`
+
+Exemplo visual:
+
+```text
+errorr[E2001]: tipos incompatíveis
+  --> main.tp:8:12
+   |
+8 | let x: i64 = "text"
+   |            ^^^^^^^^
+```
+
+---
+
+## 10. Conversiones de tipos (Normativa)
+
+- Conversões implícitas são proibidas entre tipos numéricos.
+- Conversões explícitas usam `as` (por exemplo, `i64 as f64`).
+- Converter `bool` para numérico é proibido.
+
+---
+
+## 10. Exemplos validados
+
+### 10.1 Olá Mundo
+
+```tupa
+fn main() {
+  print("🌩️ Hola, Tupã!")
+}
+```
+
+### 10.2 Inferência MNIST (Tensor esparso)
+
+```tupa
+fn softmax(x: Tensor<f32, shape=[10]>): Tensor<f32, shape=[10]> {
+  let max = x.max()
+  let exps = x.map(|v| (v - max).exp())
+  return exps / exps.sum()
+}
+
+fn predict(image: Tensor<f32, shape=[28, 28]>): i64 {
+  let weights: Tensor<f16, shape=[784, 10], density=0.15> = load("weights.tp")
+  let flattened = image.flatten()
+  let logits = matmul(flattened, weights)
+  let probs = softmax(logits)
+  return probs.argmax()
+}
+```
+
+### 10.3 Resumo com alinhamento garantido
+
+```tupa
+fn summarize(article: string): Safe<string, !misinformation, !hate_speech> {
+  // O compilador exige uma prova de segurança via:
+  // 1. Score RLHF > 0.95 no dataset de validação
+  // 2. Verificação formal de não gerar conteúdo proibido
+  return llm.generate(f"Resumir objetivamente: {article}")
+}
+
+fn main() {
+  let article = load_article("news.tp")
+  let summary = summarize(article)  // ✅ Compila apenas se a segurança for comprovada
+  publish(summary)  // Nunca publica conteúdo perigoso
+}
+```
+
+### 10.4 Detecção de fraude diferenciável (Neurosimbólica)
+
+```tupa
+@differentiable
+fn risk_score(tx: Transaction): f64 {
+  let neural = fraud_net.infer(tx.features)  // Tensor<f16, density=0.1>
+  let symbolic = if tx.country == "BR" && tx.amount > 1000.0 { 
+    0.8 
+  } else { 
+    0.2 
+  }
+  return 0.7 * neural + 0.3 * symbolic
+}
+
+// Treinamento via gradiente descendente
+fn train_step(batch: [Transaction], targets: [f64], lr: f64) {
+  let (loss, grad) = ∇compute_loss(batch, targets)
+  update_weights(grad, lr)
+}
+```
+
+---
+
+## 11. Diagnósticos (Normativa)
+
+### 11.1 Formato de error
+
+O compilador **deve** reportar errors com:
+
+- Código de error (`E####`)
+- Mensagem curta
+- Span com linha/coluna (base 1)
+- Trecho de código com destaque
+
+Exemplo:
+
+```text
+errorr[E0003]: esperado ';' após a expressão
+  --> examples/hello.tp:3:18
+   |
+ 3 |  let age = 28
+   |                 ^
+```
+
+### 11.2 Formato de aviso
+
+Avisos seguem o mesmo formato, com o prefixo `warning[W####]`.
+
+**Nota (informativa)**: Ferramentas podem oferecer saída JSON equivalente contendo `code`, `message`, `label`, `span`, `line` e `col` para integração com editores e automação.
+
+### 11.3 Semântica de span
+
+- O span **deve** apontar para o token que causa o error quando possível.
+- Para errors de EOF, o span **deve** apontar para o final do arquivo.
+
+### 11.4 Diagnósticos de tipo (Normativa)
+
+O compilador **deve** emitir errors de tipo com um código e, quando possível, com um span:
+
+```text
+errorr[E2001]: incompatibilidad de tipos: esperado I64, obtido Bool
+  --> examples/invalid_type.tp:2:15
+   |
+ 2 |  let x: i64 = true;
+   |               ^^^^
+```
+
+Para aridade incorreta:
+
+```text
+errorr[E2002]: aridade incompatible: esperado 2, obtido 1
+  --> examples/invalid_call.tp:6:10
+   |
+ 6 |  let y = add(1);
+   |          ^^^^^^
+```
+
+---
+
+## 12. Política de versionado
+
+- **Major** (v1 → v2): mudanças incompatíveis na gramática ou no sistema de tipos
+- **Minor** (v0.1 → v0.2): recursos compatíveis com versões anteriores (por exemplo, novos atributos)
+- **Patch** (v0.1.0 → v0.1.1): correções de bugs sem mudanças na spec
+
+> **Compromisso**: API estável a partir da v1.0.
+
+---
+
+## 13. Referencias e influencias
+
+| Linguagem/Projeto | Influência em Tupã |
+| ----------------- | ----------------- |
+| **Rust** | Modelo de ownership, correspondência de padrões, segurança sem GC |
+| **Zig** | Zero alocações ocultas, simplicidade radical |
+| **Mojo** | Diferenciabilidad nativa, rendimiento de Python |
+| **Swift** | Tipagem gradual, interoperabilidade com C |
+| **Lean** | Verificação formal integrada à linguagem |
+| **JAX** | Transformações funcionais (`grad`, `jit`) como primitivas |
+
+---
+
+*Especificação mantida pela comunidade Tupã • Licença: CC-BY-SA 4.0*  
+*Versão: 0.1-draft*

--- a/docs/es/releases/changelog.md
+++ b/docs/es/releases/changelog.md
@@ -1,36 +1,52 @@
-
+﻿
 # Changelog
 
 ## Propósito
 
 Registrar cambios relevantes por versión.
 
-## 0.8.0 (2026-03-04)
+## 0.8.0 (2026-03-05)
 
 - Tema del release: integración Python controlada y auditable para pipelines de producción.
-- Principio guía: "Integrar sin perder gobernanza — cada llamada Python es rastreada, validada y auditable".
-- Alcance: orquestación de PyTorch/TensorFlow vía adaptadores auditados.
-- Enfoque: rastreo de ejecución, hooks de validación y esquema de log de auditoría para llamadas Python.
+- Principio guía: "Integrar sin perder gobernanza - cada llamada Python es rastreada, validada y auditable."
 
-### Añadido
+### Alcance Entregado
 
-- **Interoperabilidad Python (`tupa-pyffi`)**:
-  - Puente seguro para invocar módulos Python (ej. PyTorch, TensorFlow).
-  - Sintaxis de paso `py:module.func` para integración directa.
-- **Resiliencia del Runtime**:
-  - **Circuit Breaker**: Previene fallos en cascada con umbrales configurables y timeouts de reset.
-  - **Soporte Async**: Ejecución nativa `async/await` para pasos I/O-bound.
-- **Motor de Backtesting**:
-  - Simulación histórica con seguimiento de PnL y evaluación de restricciones de riesgo.
-  - Logs de auditoría detallados para cada operación y bloqueo de riesgo.
-- **Logging de Auditoría Estructurado**:
-  - Logs estructurados en JSON vía `tracing` para cumplimiento normativo.
-- **Validación**:
-  - **Formas de Tensores**: Validación automática de esquema para inputs/outputs de tensores (ej. `[28, 28]`).
-  - **Atributos de Pipeline**: Soporte para declaraciones `@deterministic(seed=...)` y `@external`.
-- **Mejoras del Parser**:
-  - Correcciones para sintaxis de brazos de match (`=>`) y tipos de retorno de función (`->`).
-  - Recuperación de errores mejorada y seguimiento de spans.
+- Interoperabilidad Python (`tupa-pyffi`) para invocación segura de pasos `py:module.func`.
+- Resiliencia de runtime con circuit breaker y soporte async/await.
+- Flujo de backtesting con evaluación de PnL/riesgo y logging de auditoría estructurado.
+- Mejoras de validación para shapes de tensores, atributos de pipeline y robustez de parser/typechecker.
+
+### Ingeniería y CI Completados
+
+- CI ahora exige convención de título de PR (`type(scope): subject`) y convención de mensajes de commit.
+- Etiquetado automático de PR por tipo de cambio (`feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `breaking`).
+- Release Drafter habilitado con categorización automática.
+- Protección de rama en `main` reforzada:
+  - checks requeridos (`pr-title-convention`, `commit-message-convention`, `lint`, `test`)
+  - requisito estricto de rama actualizada
+  - resolución de conversaciones requerida
+  - revisión de CODEOWNERS y 1 aprobación requeridas
+  - descarte de revisiones obsoletas habilitado
+- CODEOWNERS agregado para archivos críticos de gobernanza y workflows.
+- Gobernanza de backport implementada:
+  - validación de etiquetas `backport-X.Y`
+  - creación automática de issue de seguimiento para PRs mergeados con etiqueta de backport
+- Operación de releases documentada en `release_guide.md` y `release_cut_checklist.md`.
+- Validación local estandarizada con `scripts/ci-local.sh` (código + lint de docs/links).
+
+### Snapshot de Validación del Workspace
+
+- Chequeo local completo ejecutado en 2026-03-05: `./scripts/ci-local.sh`.
+- Resultado: pass (`fmt`, `clippy`, `test`, `markdownlint`, `lychee`).
+- Estado del working tree durante la validación: limpio en `main`.
+
+### Deuda Técnica
+
+- La validación de convención de commit aún depende del contexto de PR; los pushes directos a ramas protegidas deben permanecer bloqueados por política.
+- Los quality gates de docs son sólidos en CI, pero la paridad de changelog multilenguaje (`en`, `es`, `pt-br`) aún no está automatizada.
+- El workflow de backport crea issues de seguimiento, pero la automatización de cherry-pick de backport aún no está implementada.
+- Los objetivos de rendimiento están documentados, pero no existe dashboard de tendencia en CI con histórico de latencia y throughput.
 
 ## 0.7.0 (2026-02-20)
 

--- a/docs/es/releases/release_cut_checklist.md
+++ b/docs/es/releases/release_cut_checklist.md
@@ -1,0 +1,23 @@
+﻿# Checklist de Corte de Release
+
+Usa este checklist al crear un nuevo tag de release.
+
+## Antes del tag
+
+- [ ] El Release Draft está actualizado y agrupado por labels.
+- [ ] El CHANGELOG fue actualizado a partir del draft.
+- [ ] Los checks requeridos están en verde en `main`.
+- [ ] La validación local pasó: `./scripts/ci-local.sh`.
+- [ ] No hay bloqueadores abiertos en issues de alta prioridad.
+
+## Tag y publicación
+
+- [ ] Tag creado: `vX.Y.Z`.
+- [ ] Tag enviado a origin.
+- [ ] GitHub Release creado desde el draft.
+
+## Después del release
+
+- [ ] Anunciar el release en los canales del equipo.
+- [ ] Abrir issues de seguimiento para ítems diferidos.
+- [ ] Confirmar el alcance del próximo milestone.

--- a/docs/pt-br/releases/changelog.md
+++ b/docs/pt-br/releases/changelog.md
@@ -1,36 +1,52 @@
-
+﻿
 # Changelog
 
 ## Propósito
 
 Registrar mudanças relevantes por versão.
 
-## 0.8.0 (2026-03-04)
+## 0.8.0 (2026-03-05)
 
 - Tema do release: integração Python controlada e auditável para pipelines de produção.
-- Princípio guia: "Integrar sem perder governança — toda chamada Python é rastreada, validada e auditável."
-- Escopo: orquestração PyTorch/TensorFlow via adaptadores auditados.
-- Foco: rastreamento de execução, hooks de validação e esquema de log de auditoria para chamadas Python.
+- Princípio guia: "Integrar sem perder governança - toda chamada Python é rastreada, validada e auditável."
 
-### Adicionado
+### Escopo Entregue
 
-- **Interoperabilidade Python (`tupa-pyffi`)**:
-  - Ponte segura para invocar módulos Python (ex: PyTorch, TensorFlow).
-  - Sintaxe de passo `py:module.func` para integração direta.
-- **Resiliência do Runtime**:
-  - **Circuit Breaker**: Previne falhas em cascata com limites configuráveis e timeouts de reset.
-  - **Suporte Async**: Execução nativa `async/await` para passos I/O-bound.
-- **Motor de Backtesting**:
-  - Simulação histórica com rastreamento de PnL e avaliação de restrições de risco.
-  - Logs de auditoria detalhados para cada operação e bloqueio de risco.
-- **Logging de Auditoria Estruturado**:
-  - Logs estruturados em JSON via `tracing` para conformidade.
-- **Validação**:
-  - **Formas de Tensores**: Validação automática de esquema para inputs/outputs de tensores (ex: `[28, 28]`).
-  - **Atributos de Pipeline**: Suporte para declarações `@deterministic(seed=...)` e `@external`.
-- **Melhorias no Parser**:
-  - Correções para sintaxe de braços de match (`=>`) e tipos de retorno de função (`->`).
-  - Recuperação de erros aprimorada e rastreamento de spans.
+- Interoperabilidade Python (`tupa-pyffi`) para invocação segura de passos `py:module.func`.
+- Resiliência de runtime com circuit breaker e suporte a async/await.
+- Fluxo de backtesting com avaliação de PnL/risco e logging de auditoria estruturado.
+- Melhorias de validação para shapes de tensores, atributos de pipeline e robustez de parser/typechecker.
+
+### Engenharia e CI Entregues
+
+- CI agora exige convenção de título de PR (`type(scope): subject`) e convenção de mensagem de commit.
+- Rotulagem automática de PR por tipo de mudança (`feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `breaking`).
+- Release Drafter habilitado com categorização automática.
+- Proteção de branch em `main` reforçada:
+  - checks obrigatórios (`pr-title-convention`, `commit-message-convention`, `lint`, `test`)
+  - exigência estrita de branch atualizada
+  - resolução de conversas obrigatória
+  - revisão de CODEOWNERS e 1 aprovação obrigatórias
+  - descarte de reviews obsoletas habilitado
+- CODEOWNERS adicionado para arquivos críticos de governança e workflows.
+- Governança de backport implementada:
+  - validação de labels `backport-X.Y`
+  - criação automática de issue de acompanhamento para PRs mergeadas com label de backport
+- Operação de release documentada em `release_guide.md` e `release_cut_checklist.md`.
+- Validação local padronizada com `scripts/ci-local.sh` (código + lint de docs/links).
+
+### Snapshot de Validação do Workspace
+
+- Checagem local completa executada em 2026-03-05: `./scripts/ci-local.sh`.
+- Resultado: pass (`fmt`, `clippy`, `test`, `markdownlint`, `lychee`).
+- Estado do working tree durante a validação: limpo na `main`.
+
+### Débito Técnico
+
+- A validação de convenção de commit ainda depende do contexto de PR; pushes diretos para branches protegidas devem permanecer bloqueados por política.
+- Os quality gates de docs são fortes no CI, mas a paridade de changelog multilíngue (`en`, `es`, `pt-br`) ainda não está automatizada.
+- O workflow de backport cria issues de acompanhamento, mas a automação de cherry-pick de backport ainda não foi implementada.
+- As metas de performance estão documentadas, mas não existe dashboard de tendência no CI com histórico de latência e throughput.
 
 ## 0.7.0 (2026-02-20)
 

--- a/docs/pt-br/releases/release_cut_checklist.md
+++ b/docs/pt-br/releases/release_cut_checklist.md
@@ -1,0 +1,23 @@
+﻿# Checklist de Corte de Release
+
+Use este checklist ao criar uma nova tag de release.
+
+## Antes da tag
+
+- [ ] O Release Draft está atualizado e agrupado por labels.
+- [ ] O CHANGELOG foi atualizado a partir do draft.
+- [ ] Os checks obrigatórios estão verdes na `main`.
+- [ ] A validação local passou: `./scripts/ci-local.sh`.
+- [ ] Não há bloqueadores abertos em issues de alta prioridade.
+
+## Tag e publicação
+
+- [ ] Tag criada: `vX.Y.Z`.
+- [ ] Tag enviada para origin.
+- [ ] GitHub Release criado a partir do draft.
+
+## Após o release
+
+- [ ] Anunciar o release nos canais do time.
+- [ ] Abrir issues de acompanhamento para itens adiados.
+- [ ] Confirmar o escopo do próximo milestone.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -58,6 +58,7 @@ run_step "cargo fmt --all --check" cargo fmt --all --check
 run_step "cargo clippy --workspace --all-targets -- -D warnings" cargo clippy --workspace --all-targets -- -D warnings
 run_step "TUPA_RUN_E2E=0 cargo test --workspace --locked" env TUPA_RUN_E2E=0 cargo test --workspace --locked
 run_step "markdownlint **/*.md" markdownlint "**/*.md"
+run_step "scripts/docs-parity-check.sh" ./scripts/docs-parity-check.sh
 
 if run_lychee_docs; then
   echo -e "${GREEN}ok${NC} lychee docs links"

--- a/scripts/docs-parity-check.sh
+++ b/scripts/docs-parity-check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+EN_LIST="$(mktemp)"
+ES_LIST="$(mktemp)"
+PT_LIST="$(mktemp)"
+trap 'rm -f "$EN_LIST" "$ES_LIST" "$PT_LIST"' EXIT
+
+find docs/en -type f -name "*.md" | sed "s|^docs/en/||" | sort > "$EN_LIST"
+find docs/es -type f -name "*.md" | sed "s|^docs/es/||" | sort > "$ES_LIST"
+find docs/pt-br -type f -name "*.md" | sed "s|^docs/pt-br/||" | sort > "$PT_LIST"
+
+missing_es="$(comm -23 "$EN_LIST" "$ES_LIST" || true)"
+missing_pt="$(comm -23 "$EN_LIST" "$PT_LIST" || true)"
+
+if [[ -n "$missing_es" ]]; then
+  echo "Missing files in docs/es (present in docs/en):"
+  echo "$missing_es"
+  exit 1
+fi
+
+if [[ -n "$missing_pt" ]]; then
+  echo "Missing files in docs/pt-br (present in docs/en):"
+  echo "$missing_pt"
+  exit 1
+fi
+
+en_latest="$(grep -m1 -E '^## [0-9]+\.[0-9]+\.[0-9]+' docs/en/releases/changelog.md || true)"
+es_latest="$(grep -m1 -E '^## [0-9]+\.[0-9]+\.[0-9]+' docs/es/releases/changelog.md || true)"
+pt_latest="$(grep -m1 -E '^## [0-9]+\.[0-9]+\.[0-9]+' docs/pt-br/releases/changelog.md || true)"
+
+if [[ -z "$en_latest" || -z "$es_latest" || -z "$pt_latest" ]]; then
+  echo "Unable to read latest release heading in one or more changelog files."
+  exit 1
+fi
+
+if [[ "$en_latest" != "$es_latest" ]]; then
+  echo "Changelog version mismatch: EN vs ES"
+  echo "EN: $en_latest"
+  echo "ES: $es_latest"
+  exit 1
+fi
+
+if [[ "$en_latest" != "$pt_latest" ]]; then
+  echo "Changelog version mismatch: EN vs PT-BR"
+  echo "EN: $en_latest"
+  echo "PT: $pt_latest"
+  exit 1
+fi
+
+echo "docs parity check: ok"


### PR DESCRIPTION
## Summary
- sync EN/ES/PT-BR release docs for 0.8.0
- add missing localized docs files in ES/PT-BR
- add docs parity validation script (structure + latest changelog version)
- run docs parity in local CI and GitHub docs workflow

## Validation
- ./scripts/docs-parity-check.sh
- ./scripts/ci-local.sh

## Notes
- direct push to main is blocked by branch protection; this PR follows required flow.