### PR TITLE
feat(release): adopt hybrid distribution plan for v0.8.0-rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release Artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-artifacts:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: tupa-linux-x86_64
+            binary_path: target/release/tupa-cli
+          - os: macos-latest
+            artifact_name: tupa-macos-aarch64
+            binary_path: target/release/tupa-cli
+          - os: windows-latest
+            artifact_name: tupa-windows-x86_64.exe
+            binary_path: target/release/tupa-cli.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release -p tupa-cli
+
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          cp "${{ matrix.binary_path }}" "${{ matrix.artifact_name }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}
+
+  publish-github-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten artifact directory
+        run: |
+          find dist -type f -maxdepth 3 -exec cp {} dist/ \;
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum tupa-* > checksums.txt
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/tupa-linux-x86_64
+            dist/tupa-macos-aarch64
+            dist/tupa-windows-x86_64.exe
+            dist/checksums.txt

--- a/docs/en/governance/hybrid_distribution_decision.md
+++ b/docs/en/governance/hybrid_distribution_decision.md
@@ -1,0 +1,40 @@
+# Hybrid Distribution Decision (Standalone Binary + Public Rust Crates)
+
+## Status
+
+Accepted for `v0.8.0-rc`.
+
+## Context
+
+Tupa must serve two distinct audiences:
+
+- End users (ML/compliance/platform teams) who need a simple executable distribution.
+- Rust integrators who need embeddability through stable crates.
+
+A binary-only strategy hurts embeddability. A crate-only strategy hurts adoption and operations.
+
+## Decision
+
+Tupa adopts a hybrid distribution model:
+
+1. Primary distribution: standalone CLI binary (`tupa-cli`) published as release artifacts.
+2. Secondary distribution: selected public Rust crates for embedding (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`).
+3. Shared core: one codebase and one CI policy for both surfaces.
+
+## Scope for `v0.8.0-rc`
+
+- Add release workflow to build and publish multi-platform binaries plus checksums.
+- Document binary installation and Rust embedding flows.
+- Keep API-stability commitments limited to the selected crates above.
+
+## Out of Scope for this RC
+
+- Homebrew tap automation.
+- Official Docker image publishing.
+- External installer endpoint (for example, `tupa.dev/install.sh`).
+
+## Consequences
+
+- Better adoption path for non-Rust users.
+- Maintained embeddability for Rust ecosystems.
+- Clearer release responsibilities (artifacts + checksums + docs).

--- a/docs/en/guides/installation.md
+++ b/docs/en/guides/installation.md
@@ -1,0 +1,37 @@
+# Installation Guide
+
+## Recommended Path (Standalone Binary)
+
+Download a release artifact and place it on your `PATH`.
+
+### Linux x86_64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-linux-x86_64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### macOS arm64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-macos-aarch64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### Windows x86_64
+
+Download `tupa-windows-x86_64.exe` from Releases and add it to your `PATH`.
+
+## Verify Installation
+
+```bash
+tupa --help
+```
+
+## Rust Developer Path (Cargo)
+
+```bash
+cargo install tupa-cli
+```
+
+If installed via Cargo, the executable is usually `tupa-cli`.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -8,7 +8,7 @@ Everything needed to learn, build, and ship with Tupã — from the quick start 
 
 English is the canonical source. Translations:
 
-- PT‑BR: [docs/pt-br](../pt-br/index.md)
+- PT-BR: [docs/pt-br](../pt-br/index.md)
 - ES: [docs/es](../es/index.md)
 
 ## Single Source of Truth
@@ -18,6 +18,7 @@ Wiki pages mirror this directory (`docs/`). Avoid manual edits in the wiki.
 ## For Users
 
 - [Quick Start](guides/getting_started.md)
+- [Installation](guides/installation.md)
 - [Examples](../../examples/README.md) • [Safe examples](../../examples/README.md#files)
 - [SPEC](reference/spec.md) • [Glossary](reference/glossary.md)
 - [Examples Guide](guides/examples_guide.md) • [Tutorials](guides/tutorials.md)
@@ -36,7 +37,9 @@ Wiki pages mirror this directory (`docs/`). Avoid manual edits in the wiki.
 - [How to Contribute](../../CONTRIBUTING.md) • [Code of Conduct](../../CODE_OF_CONDUCT.md)
 - [Dev Environment](guides/dev_env.md) • [Testing](guides/testing.md)
 - [Diagnostics: Checklist](reference/diagnostics_checklist.md) • [Glossary](reference/diagnostics_glossary.md)
+- [Embedding API](reference/embedding.md)
 
 ## Internals & Planning
 
 - Releases: [Changelog](releases/changelog.md) • [Guide](releases/release_guide.md)
+- Governance: [Hybrid Distribution Decision](governance/hybrid_distribution_decision.md)

--- a/docs/en/reference/api_extensibility.md
+++ b/docs/en/reference/api_extensibility.md
@@ -2,7 +2,17 @@
 
 ## Purpose
 
-This document explains how to use Tupã's internal compiler API, extend functionality, and add new backends.
+This document explains how to use Tupã's compiler API, extend functionality, and embed Tupã in Rust systems.
+
+## Stable Embedding Surface (`v0.8.0-rc`)
+
+The stable embedding surface for this RC cycle is:
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+For minimal embedding examples, see [Embedding](embedding.md).
 
 ## Library Usage
 
@@ -28,23 +38,11 @@ let ir = codegen(&typed)?;
 ## Example: Adding a WASM Backend
 
 1. Create a new crate `tupa-backend-wasm`.
-
-2. Implement the `CodegenBackend` trait:
-
-```rust
-pub trait CodegenBackend {
-    fn emit(&self, ir: &IrModule) -> Result<String, Error>;
-}
-```
-
-1. Integrate it into the CLI:
-
-```rust
-// ...existing code...
-let wasm = tupa_backend_wasm::emit(&ir)?;
-```
+2. Implement the `CodegenBackend` trait.
+3. Integrate it into the CLI.
 
 ## Useful Links
 
+- [Embedding](embedding.md)
 - [Codegen](codegen.md)
 - [Contribution](../../CONTRIBUTING.md)

--- a/docs/en/reference/embedding.md
+++ b/docs/en/reference/embedding.md
@@ -1,0 +1,32 @@
+# Embedding Tupã in Rust
+
+## Purpose
+
+Describe the supported embedding surface for `v0.8.0-rc`.
+
+## Supported Public Crates
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+These crates are the stable embedding surface for this RC cycle.
+
+## Minimal Example
+
+```rust
+use tupa_parser::parse;
+use tupa_typecheck::typecheck;
+
+fn main() -> anyhow::Result<()> {
+    let src = "fn main() { print(1) }";
+    let ast = parse(src)?;
+    let _typed = typecheck(&ast)?;
+    Ok(())
+}
+```
+
+## Compatibility Notes
+
+- Follow SemVer constraints from [Versioning](versioning.md).
+- Avoid depending on internal crates not listed above if you need API stability.

--- a/docs/en/reference/spec.md
+++ b/docs/en/reference/spec.md
@@ -1070,5 +1070,14 @@ error[E2002]: arity mismatch: expected 2, got 1
 
 ---
 
+## 14. Distribution Model (Informative)
+
+For `v0.8.0-rc`, Tupã uses a hybrid distribution model:
+
+- Standalone binary artifacts for end-user execution and operations.
+- Public Rust crates (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`) for embedding in Rust systems.
+
+This section is informative and does not change normative grammar or typing rules.
+
 *Specification maintained by the Tupã community • License: CC-BY-SA 4.0*  
 *Version: 0.1-draft*

--- a/docs/en/reference/versioning.md
+++ b/docs/en/reference/versioning.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the versioning and compatibility policy.
+This document defines versioning and compatibility policy for language, crates, and binary distribution.
 
 ## SemVer
 
@@ -15,6 +15,22 @@ We follow [SemVer](https://semver.org/):
 ## Pre-1.0
 
 Before 1.0, changes can happen more frequently. We still follow SemVer and document breaking changes in CHANGELOG.
+
+## Release Candidates
+
+Release candidates use the `vX.Y.Z-rc.N` format and must be treated as pre-GA builds.
+
+- RC tags publish release artifacts for validation.
+- API guarantees are limited to documented stable surfaces.
+
+## Distribution Model (v0.8.0-rc)
+
+Tupa uses a hybrid model:
+
+- Standalone binary artifacts for end-user adoption.
+- Public Rust crates for embedding in Rust systems.
+
+See [Hybrid Distribution Decision](../governance/hybrid_distribution_decision.md).
 
 ## Documentation Sync
 

--- a/docs/es/governance/hybrid_distribution_decision.md
+++ b/docs/es/governance/hybrid_distribution_decision.md
@@ -1,0 +1,40 @@
+# Decisión de Distribución Híbrida (Binario Standalone + Crates Rust Públicas)
+
+## Estado
+
+Aceptada para `v0.8.0-rc`.
+
+## Contexto
+
+Tupa debe atender dos audiencias distintas:
+
+- Usuarios finales (equipos de ML/compliance/plataforma) que necesitan distribución simple por ejecutable.
+- Integradores Rust que necesitan embeddability mediante crates estables.
+
+Una estrategia solo binario perjudica la embeddability. Una estrategia solo crates perjudica la adopción y operación.
+
+## Decisión
+
+Tupa adopta un modelo de distribución híbrido:
+
+1. Distribución principal: binario CLI standalone (`tupa-cli`) publicado en artifacts de release.
+2. Distribución secundaria: crates Rust públicas seleccionadas para embedding (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`).
+3. Núcleo compartido: un código base y una política de CI para ambas superficies.
+
+## Alcance para `v0.8.0-rc`
+
+- Agregar workflow de release para generar/publicar binarios multiplataforma y checksums.
+- Documentar instalación por binario y flujo de embedding en Rust.
+- Mantener compromisos de estabilidad de API solo para las crates seleccionadas.
+
+## Fuera de Alcance para este RC
+
+- Automatización de Homebrew tap.
+- Publicación de imagen Docker oficial.
+- Endpoint externo de instalador (por ejemplo, `tupa.dev/install.sh`).
+
+## Consecuencias
+
+- Mejor camino de adopción para usuarios no Rust.
+- Embeddability preservada para ecosistemas Rust.
+- Responsabilidades de release más claras (artifacts + checksums + docs).

--- a/docs/es/guides/installation.md
+++ b/docs/es/guides/installation.md
@@ -1,0 +1,37 @@
+# Guía de Instalación
+
+## Ruta recomendada (binario standalone)
+
+Descarga un artifact de release y colócalo en tu `PATH`.
+
+### Linux x86_64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-linux-x86_64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### macOS arm64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-macos-aarch64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### Windows x86_64
+
+Descarga `tupa-windows-x86_64.exe` en Releases y agrégalo a tu `PATH`.
+
+## Verificar instalación
+
+```bash
+tupa --help
+```
+
+## Ruta para desarrolladores Rust (Cargo)
+
+```bash
+cargo install tupa-cli
+```
+
+Si instalas por Cargo, el ejecutable normalmente es `tupa-cli`.

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -15,6 +15,7 @@ Las páginas del wiki se replican automáticamente desde `docs/`. Evita editar e
 ## Para usuarios
 
 - [Guía de inicio rápido](guides/getting_started.md)
+- [Guía de instalación](guides/installation.md)
 - [Ejemplos](../../examples/README.md)
 - [Ejemplos Safe (restricciones éticas)](../../examples/README.md#files)
 - [Glosario](reference/glossary.md)
@@ -47,6 +48,7 @@ Las páginas del wiki se replican automáticamente desde `docs/`. Evita editar e
 - [Glosario de diagnósticos](reference/diagnostics_glossary.md)
 - [Guía de pruebas](guides/testing.md)
 - [Guía de mensajes de error](reference/error_messages.md)
+- [Embedding API](reference/embedding.md)
 
 ## Internos y planificación
 
@@ -59,3 +61,4 @@ Las páginas del wiki se replican automáticamente desde `docs/`. Evita editar e
 - [Checklist de release](releases/release_checklist.md)
 - [Guía de release](releases/release_guide.md)
 - [Guía de versionado](reference/versioning.md)
+- [Decisión de distribución híbrida](governance/hybrid_distribution_decision.md)

--- a/docs/es/reference/api_extensibility.md
+++ b/docs/es/reference/api_extensibility.md
@@ -2,7 +2,17 @@
 
 ## Propósito
 
-Explicar cómo usar la API interna del compilador Tupã, extender funcionalidad y agregar nuevos backends.
+Explicar cómo usar la API del compilador de Tupã, extender funcionalidad y hacer embedding de Tupã en sistemas Rust.
+
+## Superficie estable de embedding (`v0.8.0-rc`)
+
+La superficie estable de embedding para este ciclo RC es:
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+Para ejemplos mínimos, ver [Embedding](embedding.md).
 
 ## Uso como biblioteca
 
@@ -21,30 +31,18 @@ let ir = codegen(&typed)?;
 ## Puntos de extensión
 
 - **Nuevos tipos**: implementar y registrar en `tupa-typecheck`.
-- **Nuevos diagnósticos**: añadirlos en cada módulo de errores de las crates.
+- **Nuevos diagnósticos**: añadir en cada módulo de errores de las crates.
 - **Nuevo backend**: crear una crate (por ejemplo, `tupa-backend-wasm`) e implementar el trait `CodegenBackend`.
 - **CLI personalizado**: usar `tupa-cli` como base y agregar comandos.
 
-## Ejemplo: agregando un backend WASM
+## Ejemplo: backend WASM
 
-1. Crea una nueva crate `tupa-backend-wasm`.
-
-2. Implementa el trait `CodegenBackend`:
-
-```rust
-pub trait CodegenBackend {
-    fn emit(&self, ir: &IrModule) -> Result<String, Error>;
-}
-```
-
-1. Intégralo en el CLI:
-
-```rust
-// ...existing code...
-let wasm = tupa_backend_wasm::emit(&ir)?;
-```
+1. Crear una nueva crate `tupa-backend-wasm`.
+2. Implementar el trait `CodegenBackend`.
+3. Integrarlo en el CLI.
 
 ## Enlaces útiles
 
+- [Embedding](embedding.md)
 - [Codegen](codegen.md)
 - [Contribución](../../CONTRIBUTING.md)

--- a/docs/es/reference/embedding.md
+++ b/docs/es/reference/embedding.md
@@ -1,0 +1,32 @@
+# Embedding de Tupã en Rust
+
+## Propósito
+
+Describir la superficie soportada de embedding para `v0.8.0-rc`.
+
+## Crates públicas soportadas
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+Estas crates son la superficie estable de embedding para este ciclo RC.
+
+## Ejemplo mínimo
+
+```rust
+use tupa_parser::parse;
+use tupa_typecheck::typecheck;
+
+fn main() -> anyhow::Result<()> {
+    let src = "fn main() { print(1) }";
+    let ast = parse(src)?;
+    let _typed = typecheck(&ast)?;
+    Ok(())
+}
+```
+
+## Notas de compatibilidad
+
+- Sigue SemVer según [Versionado](versioning.md).
+- Evita depender de crates internas no listadas arriba si necesitas estabilidad de API.

--- a/docs/es/reference/spec.md
+++ b/docs/es/reference/spec.md
@@ -1070,5 +1070,14 @@ errorr[E2002]: aridade incompatible: esperado 2, obtido 1
 
 ---
 
+## 14. Modelo de distribución (Informativo)
+
+Para `v0.8.0-rc`, Tupã usa un modelo híbrido de distribución:
+
+- Artifacts binarios standalone para ejecución y operación por usuarios finales.
+- Crates Rust públicas (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`) para embedding en sistemas Rust.
+
+Esta sección es informativa y no cambia reglas normativas de gramática o tipado.
+
 *Especificação mantida pela comunidade Tupã • Licença: CC-BY-SA 4.0*  
 *Versão: 0.1-draft*

--- a/docs/es/reference/versioning.md
+++ b/docs/es/reference/versioning.md
@@ -2,7 +2,7 @@
 
 ## Propósito
 
-Definir la política de versionado y compatibilidad.
+Definir la política de versionado y compatibilidad para lenguaje, crates y distribución binaria.
 
 ## SemVer
 
@@ -12,11 +12,25 @@ Seguimos [SemVer](https://semver.org/):
 - **MINOR**: nuevas features compatibles.
 - **PATCH**: correcciones compatibles.
 
-## Política
-
 ## Pre-1.0
 
 Antes de 1.0, los cambios pueden ocurrir con más frecuencia. Seguimos SemVer y documentamos cambios incompatibles en CHANGELOG.
+
+## Release Candidates
+
+Los release candidates usan el formato `vX.Y.Z-rc.N` y deben tratarse como builds pre-GA.
+
+- Los tags RC publican artifacts de release para validación.
+- Las garantías de API se limitan a superficies estables documentadas.
+
+## Modelo de distribución (v0.8.0-rc)
+
+Tupa usa un modelo híbrido:
+
+- Artifacts binarios standalone para adopción de usuarios finales.
+- Crates Rust públicas para embedding en sistemas Rust.
+
+Ver [Decisión de distribución híbrida](../governance/hybrid_distribution_decision.md).
 
 ## Sincronización de documentación
 

--- a/docs/pt-br/governance/hybrid_distribution_decision.md
+++ b/docs/pt-br/governance/hybrid_distribution_decision.md
@@ -1,0 +1,40 @@
+# Decisão de Distribuição Híbrida (Binário Standalone + Crates Rust Públicas)
+
+## Status
+
+Aceita para `v0.8.0-rc`.
+
+## Contexto
+
+Tupa precisa atender dois públicos distintos:
+
+- Usuários finais (times de ML/compliance/plataforma) que precisam de distribuição simples por executável.
+- Integradores Rust que precisam de embeddability via crates estáveis.
+
+Uma estratégia apenas binário prejudica embeddability. Uma estratégia apenas crates prejudica adoção e operação.
+
+## Decisão
+
+Tupa adota um modelo de distribuição híbrido:
+
+1. Distribuição principal: binário CLI standalone (`tupa-cli`) publicado como artefato de release.
+2. Distribuição secundária: crates Rust públicas selecionadas para embedding (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`).
+3. Núcleo compartilhado: uma base de código e uma política de CI para as duas superfícies.
+
+## Escopo para `v0.8.0-rc`
+
+- Adicionar workflow de release para gerar/publicar binários multiplataforma e checksums.
+- Documentar instalação por binário e fluxo de embedding em Rust.
+- Manter compromisso de estabilidade de API apenas para as crates selecionadas.
+
+## Fora de Escopo deste RC
+
+- Automação de Homebrew tap.
+- Publicação de imagem Docker oficial.
+- Endpoint externo de instalador (por exemplo, `tupa.dev/install.sh`).
+
+## Consequências
+
+- Melhor caminho de adoção para usuários não Rust.
+- Embeddability preservada para ecossistemas Rust.
+- Responsabilidades de release mais claras (artefatos + checksums + docs).

--- a/docs/pt-br/guides/installation.md
+++ b/docs/pt-br/guides/installation.md
@@ -1,0 +1,37 @@
+# Guia de Instalação
+
+## Caminho recomendado (binário standalone)
+
+Baixe um artefato de release e coloque no seu `PATH`.
+
+### Linux x86_64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-linux-x86_64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### macOS arm64
+
+```bash
+curl -L https://github.com/marciopaiva/tupalang/releases/latest/download/tupa-macos-aarch64 -o /usr/local/bin/tupa
+chmod +x /usr/local/bin/tupa
+```
+
+### Windows x86_64
+
+Baixe `tupa-windows-x86_64.exe` em Releases e adicione ao seu `PATH`.
+
+## Verificar instalação
+
+```bash
+tupa --help
+```
+
+## Caminho para desenvolvedores Rust (Cargo)
+
+```bash
+cargo install tupa-cli
+```
+
+Se instalar via Cargo, o executável normalmente é `tupa-cli`.

--- a/docs/pt-br/reference/api_extensibility.md
+++ b/docs/pt-br/reference/api_extensibility.md
@@ -2,7 +2,17 @@
 
 ## Propósito
 
-Explicar como usar a API interna do compilador Tupã, estender funcionalidades e adicionar novos backends.
+Explicar como usar a API do compilador do Tupã, estender funcionalidades e fazer embedding de Tupã em sistemas Rust.
+
+## Superfície estável de embedding (`v0.8.0-rc`)
+
+A superfície estável de embedding para este ciclo RC é:
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+Para exemplos mínimos, veja [Embedding](embedding.md).
 
 ## Uso como biblioteca
 
@@ -25,26 +35,14 @@ let ir = codegen(&typed)?;
 - **Novo backend**: criar uma crate (por exemplo, `tupa-backend-wasm`) e implementar o trait `CodegenBackend`.
 - **CLI customizado**: usar `tupa-cli` como base e adicionar comandos.
 
-## Exemplo: adicionando um backend WASM
+## Exemplo: backend WASM
 
-1. Crie uma nova crate `tupa-backend-wasm`.
-
-2. Implemente o trait `CodegenBackend`:
-
-```rust
-pub trait CodegenBackend {
-    fn emit(&self, ir: &IrModule) -> Result<String, Error>;
-}
-```
-
-1. Integre no CLI:
-
-```rust
-// ...existing code...
-let wasm = tupa_backend_wasm::emit(&ir)?;
-```
+1. Criar uma nova crate `tupa-backend-wasm`.
+2. Implementar o trait `CodegenBackend`.
+3. Integrar no CLI.
 
 ## Links úteis
 
+- [Embedding](embedding.md)
 - [Codegen](codegen.md)
-- [Contribuição](../CONTRIBUTING.md)
+- [Contribuição](../../CONTRIBUTING.md)

--- a/docs/pt-br/reference/embedding.md
+++ b/docs/pt-br/reference/embedding.md
@@ -1,0 +1,32 @@
+# Embedding de Tupã em Rust
+
+## Propósito
+
+Descrever a superfície suportada de embedding para `v0.8.0-rc`.
+
+## Crates públicas suportadas
+
+- `tupa-parser`
+- `tupa-typecheck`
+- `tupa-runtime`
+
+Essas crates são a superfície estável de embedding para este ciclo RC.
+
+## Exemplo mínimo
+
+```rust
+use tupa_parser::parse;
+use tupa_typecheck::typecheck;
+
+fn main() -> anyhow::Result<()> {
+    let src = "fn main() { print(1) }";
+    let ast = parse(src)?;
+    let _typed = typecheck(&ast)?;
+    Ok(())
+}
+```
+
+## Notas de compatibilidade
+
+- Siga SemVer conforme [Versionamento](versioning.md).
+- Evite depender de crates internas não listadas acima se você precisa de estabilidade de API.

--- a/docs/pt-br/reference/spec.md
+++ b/docs/pt-br/reference/spec.md
@@ -1070,5 +1070,14 @@ error[E2002]: aridade incompatível: esperado 2, obtido 1
 
 ---
 
+## 14. Modelo de distribuição (Informativo)
+
+Para `v0.8.0-rc`, Tupã usa um modelo híbrido de distribuição:
+
+- Artefatos binários standalone para execução e operação por usuários finais.
+- Crates Rust públicas (`tupa-parser`, `tupa-typecheck`, `tupa-runtime`) para embedding em sistemas Rust.
+
+Esta seção é informativa e não altera regras normativas de gramática ou tipagem.
+
 *Especificação mantida pela comunidade Tupã • Licença: CC-BY-SA 4.0*  
 *Versão: 0.1-draft*

--- a/docs/pt-br/reference/versioning.md
+++ b/docs/pt-br/reference/versioning.md
@@ -2,7 +2,7 @@
 
 ## Propósito
 
-Definir a política de versionamento e compatibilidade.
+Definir a política de versionamento e compatibilidade para linguagem, crates e distribuição binária.
 
 ## SemVer
 
@@ -12,11 +12,25 @@ Seguimos o [SemVer](https://semver.org/):
 - **MINOR**: novas features compatíveis.
 - **PATCH**: correções compatíveis.
 
-## Política
-
 ## Pré-1.0
 
 Antes da 1.0, mudanças podem acontecer com mais frequência. Ainda seguimos SemVer e documentamos mudanças incompatíveis no CHANGELOG.
+
+## Release Candidates
+
+Release candidates usam o formato `vX.Y.Z-rc.N` e devem ser tratados como builds pré-GA.
+
+- Tags RC publicam artefatos de release para validação.
+- Garantias de API ficam limitadas às superfícies estáveis documentadas.
+
+## Modelo de distribuição (v0.8.0-rc)
+
+Tupa usa um modelo híbrido:
+
+- Artefatos binários standalone para adoção de usuários finais.
+- Crates Rust públicas para embedding em sistemas Rust.
+
+Veja [Decisão de distribuição híbrida](../governance/hybrid_distribution_decision.md).
 
 ## Sincronização de documentação
 

--- a/docs/pt-br/summary.md
+++ b/docs/pt-br/summary.md
@@ -4,9 +4,12 @@
 
 - [Início](index.md)
 - [Começo rápido](guides/getting_started.md)
+- [Guia de instalação](guides/installation.md)
 - [FAQ](guides/faq.md)
 - [Especificação da Linguagem (SPEC)](reference/spec.md)
 - [Checklist de diagnósticos](reference/diagnostics_checklist.md)
 - [Tutoriais](guides/tutorials.md)
+- [Embedding API](reference/embedding.md)
 - [Changelog](releases/changelog.md)
+- [Decisão de distribuição híbrida](governance/hybrid_distribution_decision.md)
 - [Guia de contribuição](../../CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- define the hybrid distribution decision (standalone binary + public Rust crates) in EN/ES/PT-BR governance docs
- add installation guides and embedding references in EN/ES/PT-BR
- update versioning, API extensibility, and SPEC (informative distribution section) in EN/ES/PT-BR
- add release workflow to build multi-platform binaries and publish checksums on tag releases

## Scope control for RC
- keeps RC scope focused on artifacts + docs + policy clarity
- explicitly leaves Homebrew, Docker publishing, and external installer endpoint out of scope for this RC

## Validation
- markdownlint on changed docs files
- ./scripts/docs-parity-check.sh