### PR TITLE
fix(ci): handle release artifacts without directory flatten conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-
-      - name: Flatten artifact directory
-        run: |
-          find dist -type f -maxdepth 3 -exec cp {} dist/ \;
+          merge-multiple: true
 
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum tupa-* > checksums.txt
+          sha256sum tupa-linux-x86_64 tupa-macos-aarch64 tupa-windows-x86_64.exe > checksums.txt
 
       - name: Publish release assets
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- fix release workflow artifact download by enabling merge-multiple
- remove flatten step that caused directory/file collisions
- generate checksums from explicit artifact filenames

## Why
Release run for 0.8.0-rc.2 failed in Generate checksums because artifact directories were treated as files.

## Validation
- workflow syntax reviewed
- paths aligned with generated artifact names