### PR TITLE
docs(crates): add per-crate README files

### DIFF
--- a/crates/tupa-audit/Cargo.toml
+++ b/crates/tupa-audit/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 serde_json = "1.0"

--- a/crates/tupa-audit/README.md
+++ b/crates/tupa-audit/README.md
@@ -14,3 +14,4 @@ let hash = hash_execution(&program, &[json!({"x": 1})]);
 println!("{} {}", compiler_version(), hash);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+

--- a/crates/tupa-audit/README.md
+++ b/crates/tupa-audit/README.md
@@ -1,0 +1,16 @@
+# tupa-audit
+
+Audit helpers for compiler/runtime versioning and deterministic hashing.
+
+## Usage
+
+```rust
+use serde_json::json;
+use tupa_audit::{compiler_version, hash_execution};
+use tupa_parser::parse_program;
+
+let program = parse_program("fn main() {}")?;
+let hash = hash_execution(&program, &[json!({"x": 1})]);
+println!("{} {}", compiler_version(), hash);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```

--- a/crates/tupa-audit/README.md
+++ b/crates/tupa-audit/README.md
@@ -14,4 +14,3 @@ let hash = hash_execution(&program, &[json!({"x": 1})]);
 println!("{} {}", compiler_version(), hash);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
-

--- a/crates/tupa-cli/Cargo.toml
+++ b/crates/tupa-cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [[bin]]
 name = "tupa"

--- a/crates/tupa-cli/README.md
+++ b/crates/tupa-cli/README.md
@@ -1,0 +1,22 @@
+# tupa-cli
+
+Command-line interface for TupaLang.
+
+## Install
+
+```bash
+cargo install tupa-cli
+```
+
+## Basic commands
+
+```bash
+tupa --help
+tupa check path/to/file.tp
+tupa run path/to/file.tp
+```
+
+## Crate
+
+- Binary name: `tupa`
+- Source: https://github.com/marciopaiva/tupalang

--- a/crates/tupa-cli/README.md
+++ b/crates/tupa-cli/README.md
@@ -19,4 +19,5 @@ tupa run path/to/file.tp
 ## Crate
 
 - Binary name: `tupa`
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
+

--- a/crates/tupa-cli/README.md
+++ b/crates/tupa-cli/README.md
@@ -20,4 +20,3 @@ tupa run path/to/file.tp
 
 - Binary name: `tupa`
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
-

--- a/crates/tupa-codegen/Cargo.toml
+++ b/crates/tupa-codegen/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 tupa-parser = { path = "../tupa-parser", version = "0.8.0" }

--- a/crates/tupa-codegen/README.md
+++ b/crates/tupa-codegen/README.md
@@ -18,4 +18,5 @@ println!("{}", plan_json);
 
 ## Crate
 
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
+

--- a/crates/tupa-codegen/README.md
+++ b/crates/tupa-codegen/README.md
@@ -1,0 +1,21 @@
+# tupa-codegen
+
+Transforms typed AST into executable artifacts (stubs and execution plans).
+
+## Usage
+
+```rust
+use tupa_parser::parse_program;
+use tupa_codegen::execution_plan::codegen_pipeline;
+
+let src = r#"pipeline P { input: string, steps: [], output: string }"#;
+let program = parse_program(src)?;
+let pipeline = program.items.iter().find_map(|i| match i { tupa_parser::Item::Pipeline(p) => Some(p), _ => None }).unwrap();
+let plan_json = codegen_pipeline("demo", pipeline, &program)?;
+println!("{}", plan_json);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Crate
+
+- Source: https://github.com/marciopaiva/tupalang

--- a/crates/tupa-codegen/README.md
+++ b/crates/tupa-codegen/README.md
@@ -19,4 +19,3 @@ println!("{}", plan_json);
 ## Crate
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
-

--- a/crates/tupa-effects/Cargo.toml
+++ b/crates/tupa-effects/Cargo.toml
@@ -7,5 +7,6 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]

--- a/crates/tupa-effects/README.md
+++ b/crates/tupa-effects/README.md
@@ -1,0 +1,10 @@
+# tupa-effects
+
+Effect model and policy primitives used by typecheck/runtime.
+
+This crate exposes shared effect definitions used across the TupaLang toolchain.
+
+## Crate
+
+- Source: https://github.com/marciopaiva/tupalang
+- License: Apache-2.0

--- a/crates/tupa-effects/README.md
+++ b/crates/tupa-effects/README.md
@@ -8,4 +8,3 @@ This crate exposes shared effect definitions used across the TupaLang toolchain.
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
-

--- a/crates/tupa-effects/README.md
+++ b/crates/tupa-effects/README.md
@@ -6,5 +6,6 @@ This crate exposes shared effect definitions used across the TupaLang toolchain.
 
 ## Crate
 
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
+

--- a/crates/tupa-fmt/Cargo.toml
+++ b/crates/tupa-fmt/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 tupa-lexer = { path = "../tupa-lexer", version = "0.8.0" }

--- a/crates/tupa-fmt/README.md
+++ b/crates/tupa-fmt/README.md
@@ -10,4 +10,3 @@ use tupa_fmt::format_source;
 let out = format_source("fn main(){return;}");
 println!("{}", out);
 ```
-

--- a/crates/tupa-fmt/README.md
+++ b/crates/tupa-fmt/README.md
@@ -1,0 +1,12 @@
+# tupa-fmt
+
+Formatter for TupaLang source code.
+
+## Usage
+
+```rust
+use tupa_fmt::format_source;
+
+let out = format_source("fn main(){return;}");
+println!("{}", out);
+```

--- a/crates/tupa-fmt/README.md
+++ b/crates/tupa-fmt/README.md
@@ -10,3 +10,4 @@ use tupa_fmt::format_source;
 let out = format_source("fn main(){return;}");
 println!("{}", out);
 ```
+

--- a/crates/tupa-lexer/Cargo.toml
+++ b/crates/tupa-lexer/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 nom = "7.1"

--- a/crates/tupa-lexer/README.md
+++ b/crates/tupa-lexer/README.md
@@ -16,4 +16,3 @@ println!("{} tokens", tokens.len());
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
-

--- a/crates/tupa-lexer/README.md
+++ b/crates/tupa-lexer/README.md
@@ -14,5 +14,6 @@ println!("{} tokens", tokens.len());
 
 ## Crate
 
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
+

--- a/crates/tupa-lexer/README.md
+++ b/crates/tupa-lexer/README.md
@@ -1,0 +1,18 @@
+# tupa-lexer
+
+Tokenizes TupaLang source code.
+
+## Usage
+
+```rust
+use tupa_lexer::lex_with_spans;
+
+let tokens = lex_with_spans("fn main() {}")?;
+println!("{} tokens", tokens.len());
+# Ok::<(), tupa_lexer::LexerError>(())
+```
+
+## Crate
+
+- Source: https://github.com/marciopaiva/tupalang
+- License: Apache-2.0

--- a/crates/tupa-lint/Cargo.toml
+++ b/crates/tupa-lint/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 tupa-parser = { path = "../tupa-parser", version = "0.8.0" }

--- a/crates/tupa-lint/README.md
+++ b/crates/tupa-lint/README.md
@@ -1,0 +1,15 @@
+# tupa-lint
+
+Linter for TupaLang AST programs.
+
+## Usage
+
+```rust
+use tupa_lint::lint_program;
+use tupa_parser::parse_program;
+
+let program = parse_program("fn main() {}")?;
+let warnings = lint_program(&program);
+println!("{} warnings", warnings.len());
+# Ok::<(), Box<dyn std::error::Error>>(())
+```

--- a/crates/tupa-lint/README.md
+++ b/crates/tupa-lint/README.md
@@ -13,3 +13,4 @@ let warnings = lint_program(&program);
 println!("{} warnings", warnings.len());
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+

--- a/crates/tupa-lint/README.md
+++ b/crates/tupa-lint/README.md
@@ -13,4 +13,3 @@ let warnings = lint_program(&program);
 println!("{} warnings", warnings.len());
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
-

--- a/crates/tupa-parser/Cargo.toml
+++ b/crates/tupa-parser/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 tupa-lexer = { path = "../tupa-lexer", version = "0.8.0" }

--- a/crates/tupa-parser/README.md
+++ b/crates/tupa-parser/README.md
@@ -15,4 +15,5 @@ println!("{} top-level items", program.items.len());
 ## Crate
 
 - Depends on `tupa-lexer`
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
+

--- a/crates/tupa-parser/README.md
+++ b/crates/tupa-parser/README.md
@@ -16,4 +16,3 @@ println!("{} top-level items", program.items.len());
 
 - Depends on `tupa-lexer`
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
-

--- a/crates/tupa-parser/README.md
+++ b/crates/tupa-parser/README.md
@@ -1,0 +1,18 @@
+# tupa-parser
+
+Parses TupaLang tokens into an AST.
+
+## Usage
+
+```rust
+use tupa_parser::parse_program;
+
+let program = parse_program("fn main() {}")?;
+println!("{} top-level items", program.items.len());
+# Ok::<(), tupa_parser::ParserError>(())
+```
+
+## Crate
+
+- Depends on `tupa-lexer`
+- Source: https://github.com/marciopaiva/tupalang

--- a/crates/tupa-pyffi/Cargo.toml
+++ b/crates/tupa-pyffi/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 pyo3 = { version = "0.21", features = ["auto-initialize"] }

--- a/crates/tupa-pyffi/README.md
+++ b/crates/tupa-pyffi/README.md
@@ -1,0 +1,16 @@
+# tupa-pyffi
+
+Python FFI bridge for calling external Python functions from Tupa runtime.
+
+## Usage
+
+```rust
+use serde_json::json;
+use tupa_pyffi::call_python_function;
+
+let _ = call_python_function("module", "func", json!({"x": 1}));
+```
+
+## Notes
+
+- Requires Python runtime/toolchain in build or runtime environment.

--- a/crates/tupa-pyffi/README.md
+++ b/crates/tupa-pyffi/README.md
@@ -14,3 +14,4 @@ let _ = call_python_function("module", "func", json!({"x": 1}));
 ## Notes
 
 - Requires Python runtime/toolchain in build or runtime environment.
+

--- a/crates/tupa-pyffi/README.md
+++ b/crates/tupa-pyffi/README.md
@@ -14,4 +14,3 @@ let _ = call_python_function("module", "func", json!({"x": 1}));
 ## Notes
 
 - Requires Python runtime/toolchain in build or runtime environment.
-

--- a/crates/tupa-runtime/Cargo.toml
+++ b/crates/tupa-runtime/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/tupa-runtime/README.md
+++ b/crates/tupa-runtime/README.md
@@ -1,0 +1,20 @@
+# tupa-runtime
+
+Execution engine for TupaLang pipelines.
+
+## Usage
+
+```rust
+use serde_json::json;
+use tupa_runtime::Runtime;
+
+let runtime = Runtime::new();
+runtime.register_step("demo::step_echo", |state| Ok(state));
+let _ = json!({"ok": true});
+```
+
+Use this crate together with execution plans produced by `tupa-codegen`.
+
+## Crate
+
+- Source: https://github.com/marciopaiva/tupalang

--- a/crates/tupa-runtime/README.md
+++ b/crates/tupa-runtime/README.md
@@ -18,4 +18,3 @@ Use this crate together with execution plans produced by `tupa-codegen`.
 ## Crate
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
-

--- a/crates/tupa-runtime/README.md
+++ b/crates/tupa-runtime/README.md
@@ -17,4 +17,5 @@ Use this crate together with execution plans produced by `tupa-codegen`.
 
 ## Crate
 
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
+

--- a/crates/tupa-typecheck/Cargo.toml
+++ b/crates/tupa-typecheck/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
 homepage = "https://github.com/marciopaiva/tupalang"
 documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 thiserror = "1.0"

--- a/crates/tupa-typecheck/README.md
+++ b/crates/tupa-typecheck/README.md
@@ -16,4 +16,5 @@ typecheck_program(&program)?;
 ## Crate
 
 - Works with `tupa-parser` AST
-- Source: https://github.com/marciopaiva/tupalang
+- Source: [tupalang](https://github.com/marciopaiva/tupalang)
+

--- a/crates/tupa-typecheck/README.md
+++ b/crates/tupa-typecheck/README.md
@@ -1,0 +1,19 @@
+# tupa-typecheck
+
+Static checks for TupaLang programs (types, determinism and constraints).
+
+## Usage
+
+```rust
+use tupa_parser::parse_program;
+use tupa_typecheck::typecheck_program;
+
+let program = parse_program("fn main() {}")?;
+typecheck_program(&program)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Crate
+
+- Works with `tupa-parser` AST
+- Source: https://github.com/marciopaiva/tupalang

--- a/crates/tupa-typecheck/README.md
+++ b/crates/tupa-typecheck/README.md
@@ -17,4 +17,3 @@ typecheck_program(&program)?;
 
 - Works with `tupa-parser` AST
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
-


### PR DESCRIPTION
Adds README.md for each crate and sets readme metadata in each Cargo.toml to improve crates.io package pages.