### PR TITLE
feat: add standard base-image build flow

### DIFF
--- a/.github/workflows/backport-label-check.yml
+++ b/.github/workflows/backport-label-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate backport label format
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Open tracking issue for backports
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Validate commit messages in PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pattern = /^(feat|fix|docs|refactor|test|ci|chore)(\([a-z0-9._/-]+\))?: .+/;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Docs parity check
         run: ./scripts/docs-parity-check.sh
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Link check
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/examples-golden.yml
+++ b/.github/workflows/examples-golden.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/examples-golden.yml
+++ b/.github/workflows/examples-golden.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: golden-generated
           path: generated/

--- a/.github/workflows/pr-type-labeler.yml
+++ b/.github/workflows/pr-type-labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR by Conventional title type
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           cp "${{ matrix.binary_path }}" "${{ matrix.artifact_name }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ chmod +x /usr/local/bin/tupa
 cargo install --locked tupa-cli
 ```
 
+### Docker base images (local standard)
+
+```bash
+./scripts/build-base-images.sh
+./scripts/build-tupa-cli-image.sh
+podman run --rm tupalang-cli:local --help
+```
+
 ## Quick Usage
 
 If you installed via release binary:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ docker run --rm tupalang-cli:local --help
 
 The build scripts auto-detect `docker` first and fall back to `podman`. You can force the engine with `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`.
 
+### Local Rust validation with the builder image
+
+After building the base images, you can run workspace validation inside the
+standard Rust builder without relying on the host toolchain:
+
+```bash
+docker run --rm \
+  -e PYO3_PYTHON=/usr/bin/python3 \
+  -v "$PWD":/work \
+  -w /work \
+  tupalang-base-rust-builder:1.93 \
+  /usr/local/cargo/bin/cargo check --workspace --locked
+
+docker run --rm \
+  -e PYO3_PYTHON=/usr/bin/python3 \
+  -v "$PWD":/work \
+  -w /work \
+  tupalang-base-rust-builder:1.93 \
+  /usr/local/cargo/bin/cargo clippy --all-targets --workspace -- -D warnings
+```
+
 ## Quick Usage
 
 If you installed via release binary:

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ cargo install --locked tupa-cli
 ```bash
 ./scripts/build-base-images.sh
 ./scripts/build-tupa-cli-image.sh
-podman run --rm tupalang-cli:local --help
+docker run --rm tupalang-cli:local --help
 ```
+
+The build scripts auto-detect `docker` first and fall back to `podman`. You can force the engine with `CONTAINER_ENGINE=docker` or `CONTAINER_ENGINE=podman`.
 
 ## Quick Usage
 

--- a/docker/base/rust-builder.Dockerfile
+++ b/docker/base/rust-builder.Dockerfile
@@ -1,0 +1,15 @@
+ARG RUST_VERSION=1.93
+FROM rust:${RUST_VERSION}-slim-bookworm
+
+ENV PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  pkg-config \
+  libssl-dev \
+  python3 \
+  python3-dev \
+  ca-certificates \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/tupalang

--- a/docker/base/rust-runtime.Dockerfile
+++ b/docker/base/rust-runtime.Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  libssl3 \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/docker/base/rust-runtime.Dockerfile
+++ b/docker/base/rust-runtime.Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   libssl3 \
+  libpython3.11 \
   curl \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/tupa-cli.Dockerfile
+++ b/docker/tupa-cli.Dockerfile
@@ -1,0 +1,20 @@
+ARG RUST_VERSION=1.93
+ARG TUPA_RUST_BUILDER_IMAGE=tupalang-base-rust-builder:${RUST_VERSION}
+ARG TUPA_RUST_RUNTIME_IMAGE=tupalang-base-rust-runtime:bookworm
+FROM ${TUPA_RUST_BUILDER_IMAGE} AS builder
+
+WORKDIR /usr/src/tupalang
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+
+RUN cargo build --release --package tupa-cli
+
+FROM ${TUPA_RUST_RUNTIME_IMAGE}
+
+COPY --from=builder /usr/src/tupalang/target/release/tupa /usr/local/bin/tupa
+
+RUN useradd -m -u 1000 -U tupa
+USER tupa
+ENTRYPOINT ["tupa"]
+CMD ["--help"]

--- a/scripts/build-base-images.sh
+++ b/scripts/build-base-images.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_DIR="$ROOT_DIR/docker/base"
+
+RUST_VERSION="${RUST_VERSION:-1.93}"
+TUPA_RUST_BUILDER_IMAGE="${TUPA_RUST_BUILDER_IMAGE:-tupalang-base-rust-builder:${RUST_VERSION}}"
+TUPA_RUST_RUNTIME_IMAGE="${TUPA_RUST_RUNTIME_IMAGE:-tupalang-base-rust-runtime:bookworm}"
+
+echo "Building Tupalang base images..."
+echo "  TUPA_RUST_BUILDER_IMAGE=$TUPA_RUST_BUILDER_IMAGE"
+echo "  TUPA_RUST_RUNTIME_IMAGE=$TUPA_RUST_RUNTIME_IMAGE"
+
+podman build -f "$BASE_DIR/rust-builder.Dockerfile" --build-arg RUST_VERSION="$RUST_VERSION" -t "$TUPA_RUST_BUILDER_IMAGE" "$ROOT_DIR"
+podman build -f "$BASE_DIR/rust-runtime.Dockerfile" -t "$TUPA_RUST_RUNTIME_IMAGE" "$ROOT_DIR"
+
+echo "Done."

--- a/scripts/build-base-images.sh
+++ b/scripts/build-base-images.sh
@@ -8,11 +8,25 @@ RUST_VERSION="${RUST_VERSION:-1.93}"
 TUPA_RUST_BUILDER_IMAGE="${TUPA_RUST_BUILDER_IMAGE:-tupalang-base-rust-builder:${RUST_VERSION}}"
 TUPA_RUST_RUNTIME_IMAGE="${TUPA_RUST_RUNTIME_IMAGE:-tupalang-base-rust-runtime:bookworm}"
 
+if [[ "${CONTAINER_ENGINE:-}" == "docker" ]]; then
+  ENGINE="docker"
+elif [[ "${CONTAINER_ENGINE:-}" == "podman" ]]; then
+  ENGINE="podman"
+elif command -v docker >/dev/null 2>&1; then
+  ENGINE="docker"
+elif command -v podman >/dev/null 2>&1; then
+  ENGINE="podman"
+else
+  echo "ERROR: docker or podman not found" >&2
+  exit 1
+fi
+
 echo "Building Tupalang base images..."
+echo "  ENGINE=$ENGINE"
 echo "  TUPA_RUST_BUILDER_IMAGE=$TUPA_RUST_BUILDER_IMAGE"
 echo "  TUPA_RUST_RUNTIME_IMAGE=$TUPA_RUST_RUNTIME_IMAGE"
 
-podman build -f "$BASE_DIR/rust-builder.Dockerfile" --build-arg RUST_VERSION="$RUST_VERSION" -t "$TUPA_RUST_BUILDER_IMAGE" "$ROOT_DIR"
-podman build -f "$BASE_DIR/rust-runtime.Dockerfile" -t "$TUPA_RUST_RUNTIME_IMAGE" "$ROOT_DIR"
+"$ENGINE" build -f "$BASE_DIR/rust-builder.Dockerfile" --build-arg RUST_VERSION="$RUST_VERSION" -t "$TUPA_RUST_BUILDER_IMAGE" "$ROOT_DIR"
+"$ENGINE" build -f "$BASE_DIR/rust-runtime.Dockerfile" -t "$TUPA_RUST_RUNTIME_IMAGE" "$ROOT_DIR"
 
 echo "Done."

--- a/scripts/build-tupa-cli-image.sh
+++ b/scripts/build-tupa-cli-image.sh
@@ -8,7 +8,20 @@ TUPA_RUST_BUILDER_IMAGE="${TUPA_RUST_BUILDER_IMAGE:-tupalang-base-rust-builder:$
 TUPA_RUST_RUNTIME_IMAGE="${TUPA_RUST_RUNTIME_IMAGE:-tupalang-base-rust-runtime:bookworm}"
 TUPA_CLI_IMAGE="${TUPA_CLI_IMAGE:-tupalang-cli:local}"
 
-podman build \
+if [[ "${CONTAINER_ENGINE:-}" == "docker" ]]; then
+  ENGINE="docker"
+elif [[ "${CONTAINER_ENGINE:-}" == "podman" ]]; then
+  ENGINE="podman"
+elif command -v docker >/dev/null 2>&1; then
+  ENGINE="docker"
+elif command -v podman >/dev/null 2>&1; then
+  ENGINE="podman"
+else
+  echo "ERROR: docker or podman not found" >&2
+  exit 1
+fi
+
+"$ENGINE" build \
   -f "$ROOT_DIR/docker/tupa-cli.Dockerfile" \
   --build-arg RUST_VERSION="$RUST_VERSION" \
   --build-arg TUPA_RUST_BUILDER_IMAGE="$TUPA_RUST_BUILDER_IMAGE" \
@@ -16,4 +29,4 @@ podman build \
   -t "$TUPA_CLI_IMAGE" \
   "$ROOT_DIR"
 
-echo "Built $TUPA_CLI_IMAGE"
+echo "Built $TUPA_CLI_IMAGE with $ENGINE"

--- a/scripts/build-tupa-cli-image.sh
+++ b/scripts/build-tupa-cli-image.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+RUST_VERSION="${RUST_VERSION:-1.93}"
+TUPA_RUST_BUILDER_IMAGE="${TUPA_RUST_BUILDER_IMAGE:-tupalang-base-rust-builder:${RUST_VERSION}}"
+TUPA_RUST_RUNTIME_IMAGE="${TUPA_RUST_RUNTIME_IMAGE:-tupalang-base-rust-runtime:bookworm}"
+TUPA_CLI_IMAGE="${TUPA_CLI_IMAGE:-tupalang-cli:local}"
+
+podman build \
+  -f "$ROOT_DIR/docker/tupa-cli.Dockerfile" \
+  --build-arg RUST_VERSION="$RUST_VERSION" \
+  --build-arg TUPA_RUST_BUILDER_IMAGE="$TUPA_RUST_BUILDER_IMAGE" \
+  --build-arg TUPA_RUST_RUNTIME_IMAGE="$TUPA_RUST_RUNTIME_IMAGE" \
+  -t "$TUPA_CLI_IMAGE" \
+  "$ROOT_DIR"
+
+echo "Built $TUPA_CLI_IMAGE"


### PR DESCRIPTION
## Summary
- add standard Docker base images for Tupalang
- add local scripts to build base images and the tupa CLI image
- document the local Docker build flow in the README
- document local `cargo check` and `cargo clippy` execution via the standard builder image
- refresh GitHub Actions runtime versions to the current `checkout` and `setup-node` majors

## Validation
- `docker run --rm tupalang-cli:local --help`
- GitHub Actions on the PR are green after the workflow refresh
