### PR TITLE
feat: add record literals for 0.8.1

### DIFF
--- a/crates/tupa-codegen/src/lib.rs
+++ b/crates/tupa-codegen/src/lib.rs
@@ -454,6 +454,11 @@ impl Codegen {
                     self.collect_used_in_expr(item, env);
                 }
             }
+            ExprKind::RecordLiteral(fields) => {
+                for (_, value) in fields {
+                    self.collect_used_in_expr(value, env);
+                }
+            }
             ExprKind::Field { expr: base, .. } => {
                 self.collect_used_in_expr(base, env);
             }

--- a/crates/tupa-parser/src/lib.rs
+++ b/crates/tupa-parser/src/lib.rs
@@ -177,6 +177,7 @@ pub enum ExprKind {
     Null,
     Ident(String),
     Tuple(Vec<Expr>),
+    RecordLiteral(Vec<(String, Expr)>),
     Assign {
         name: String,
         expr: Box<Expr>,
@@ -1713,6 +1714,9 @@ impl Parser {
     }
 
     fn parse_primary(&mut self) -> Result<Expr, ParserError> {
+        if self.is_record_literal_start() {
+            return self.parse_record_literal();
+        }
         if matches!(self.peek(), Some(Token::LBrace)) {
             let (block, span) = self.parse_block_with_span()?;
             return Ok(Expr::new(ExprKind::Block(block), span));
@@ -1949,6 +1953,57 @@ impl Parser {
         }
 
         Ok(expr)
+    }
+
+    fn is_record_literal_start(&self) -> bool {
+        matches!(
+            (
+                self.peek(),
+                self.tokens.get(self.pos + 1).map(|t| &t.token),
+                self.tokens.get(self.pos + 2).map(|t| &t.token),
+            ),
+            (
+                Some(Token::LBrace),
+                Some(Token::Ident(_)),
+                Some(Token::Colon)
+            )
+        )
+    }
+
+    fn parse_record_literal(&mut self) -> Result<Expr, ParserError> {
+        let start = self.expect_span(Token::LBrace)?;
+        let mut fields = Vec::new();
+
+        loop {
+            let field_name = match self.next() {
+                Some(TokenSpan {
+                    token: Token::Ident(name),
+                    ..
+                }) => name,
+                Some(TokenSpan { token, span }) => {
+                    return Err(ParserError::Unexpected(token, span))
+                }
+                None => return Err(ParserError::Eof(self.eof_pos)),
+            };
+            self.expect(Token::Colon)?;
+            let field_expr = self.parse_expr()?;
+            fields.push((field_name, field_expr));
+
+            if matches!(self.peek(), Some(Token::Comma)) {
+                self.next();
+                if matches!(self.peek(), Some(Token::RBrace)) {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        let end = self.expect_span(Token::RBrace)?;
+        Ok(Expr::new(
+            ExprKind::RecordLiteral(fields),
+            merge_span(start, end),
+        ))
     }
 
     fn token_to_binary_op(token: &Token) -> Option<(BinaryOp, u8, bool)> {
@@ -2398,6 +2453,31 @@ mod tests {
                 ("eligible".into(), Type::Ident("bool".into())),
             ]))
         );
+    }
+
+    #[test]
+    fn parse_record_literal() {
+        let src = "fn main() { let entry = { reason: \"ok\", score: 1.0, eligible: true }; }";
+        let program = parse_program(src).unwrap();
+        let func = match &program.items[0] {
+            Item::Trait(_) => panic!("expected function"),
+            Item::Enum(_) => panic!("expected function"),
+            Item::Pipeline(_) => panic!("expected function"),
+            Item::Function(func) => func,
+        };
+        let Stmt::Let { expr, .. } = &func.body[0] else {
+            panic!("expected let");
+        };
+        let ExprKind::RecordLiteral(fields) = &expr.kind else {
+            panic!("expected record literal");
+        };
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0].0, "reason");
+        assert!(matches!(fields[0].1.kind, ExprKind::Str(_)));
+        assert_eq!(fields[1].0, "score");
+        assert!(matches!(fields[1].1.kind, ExprKind::Float(_)));
+        assert_eq!(fields[2].0, "eligible");
+        assert!(matches!(fields[2].1.kind, ExprKind::Bool(true)));
     }
 
     #[test]

--- a/crates/tupa-typecheck/src/lib.rs
+++ b/crates/tupa-typecheck/src/lib.rs
@@ -82,6 +82,9 @@ pub fn analyze_effects(
                 fold(expr, external_effects).union(&fold(index, external_effects))
             }
             Field { expr, .. } => fold(expr, external_effects),
+            RecordLiteral(fields) => fields.iter().fold(EffectSet::default(), |acc, (_, it)| {
+                acc.union(&fold(it, external_effects))
+            }),
             Lambda { body, .. } => fold(body, external_effects),
             Block(stmts) => {
                 let mut acc = EffectSet::default();
@@ -346,6 +349,11 @@ fn collect_vars(expr: &Expr, vars: &mut std::collections::HashSet<String>) {
         }
         ExprKind::Tuple(items) => {
             for item in items {
+                collect_vars(item, vars);
+            }
+        }
+        ExprKind::RecordLiteral(fields) => {
+            for (_, item) in fields {
                 collect_vars(item, vars);
             }
         }
@@ -627,6 +635,19 @@ fn infer_lambda_param_types(
                 expected_return,
             )?;
         }
+        ExprKind::RecordLiteral(fields) => {
+            for (_, value) in fields {
+                infer_lambda_param_types(
+                    value,
+                    env,
+                    param_types,
+                    functions,
+                    enums,
+                    traits,
+                    expected_return,
+                )?;
+            }
+        }
         ExprKind::Await(expr) => {
             infer_lambda_param_types(
                 expr,
@@ -768,6 +789,11 @@ fn infer_param_type_from_expr(
         }
         ExprKind::Tuple(items) => {
             for item in items {
+                infer_param_type_from_expr(item, expected_ty.clone(), param_types, env)?;
+            }
+        }
+        ExprKind::RecordLiteral(fields) => {
+            for (_, item) in fields {
                 infer_param_type_from_expr(item, expected_ty.clone(), param_types, env)?;
             }
         }
@@ -1455,6 +1481,16 @@ fn type_of_expr(
                 )?);
             }
             Ok(Ty::Tuple(tys))
+        }
+        ExprKind::RecordLiteral(fields) => {
+            let mut field_tys = Vec::with_capacity(fields.len());
+            for (name, value) in fields {
+                field_tys.push((
+                    name.clone(),
+                    type_of_expr(value, env, functions, enums, traits, expected_return)?,
+                ));
+            }
+            Ok(Ty::Record(field_tys))
         }
         ExprKind::Ident(name) => {
             if let Some(ty) = env.get_var_and_mark(name) {
@@ -3499,6 +3535,27 @@ mod tests {
         )
         .unwrap();
         assert!(typecheck_program(&program).is_ok());
+    }
+
+    #[test]
+    fn typecheck_record_literal_assignment() {
+        let program = parse_program(
+            "fn main() { let entry: { reason: string, score: f64 } = { reason: \"ok\", score: 1.0 }; }",
+        )
+        .unwrap();
+        assert!(typecheck_program(&program).is_ok());
+    }
+
+    #[test]
+    fn typecheck_record_literal_type_mismatch() {
+        let program = parse_program(
+            "fn main() { let entry: { reason: string, score: f64 } = { reason: \"ok\", score: true }; }",
+        )
+        .unwrap();
+        assert!(matches!(
+            typecheck_program(&program),
+            Err(TypeError::Mismatch { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add record literal expressions to the parser AST\n- infer and validate record literal types in the typechecker\n- update codegen traversal so the new expression kind is workspace-safe\n\n## Validation\n- cargo test -p tupa-parser -p tupa-typecheck --offline\n- cargo check --workspace --offline\n- CI_LOCAL_SKIP_BUILD=1 IMAGE_NAME=tupalang-ci-local:test ./scripts/ci-local-container.sh