### PR TITLE
docs: refine v0.8.1 priorities from ViperTrade integration

### DIFF
--- a/docs/en/releases/rfc_v0.8.1_trading_strategy_support.md
+++ b/docs/en/releases/rfc_v0.8.1_trading_strategy_support.md
@@ -17,6 +17,7 @@ This RFC proposes a narrow, pragmatic release theme:
 - structured step outputs
 - first-class policy reasons
 - reusable predicates
+- typed config bindings
 - weighted score support
 - declarative temporal policy support
 
@@ -47,6 +48,7 @@ That split reduces the value of the language in the exact area where it should h
 - Allow steps to return typed structured results instead of only primitive values.
 - Allow strategy rules to produce machine-readable reasons directly.
 - Allow policies to be composed from reusable predicates.
+- Allow strategy policies to read typed runtime configuration without routing all semantics through host code.
 - Allow weighted scores to be expressed declaratively.
 - Allow temporal decision policies to be described without embedding all semantics in host code.
 
@@ -131,7 +133,25 @@ Desired capabilities:
 - clamp/range handling
 - threshold comparisons
 
-### 5. Declarative temporal policy support
+### 5. Typed config bindings
+
+Support typed access to host-provided configuration values used by production strategy systems.
+
+Illustrative use cases:
+
+- per-symbol thresholds
+- mode-specific overlays
+- trailing parameters
+- confirmation thresholds
+- macro filter thresholds
+
+Desired capabilities:
+
+- typed reads from a host-provided config object
+- explicit defaults or fallback rules
+- shape validation before runtime execution
+
+### 6. Declarative temporal policy support
 
 Support policy semantics that depend on persistence across evaluation cycles.
 
@@ -162,27 +182,58 @@ That would leave Rust focused on the right concerns:
 - event transport
 - risk plumbing
 
+## Priority refinement after ViperTrade integration
+
+The ViperTrade `0.8.1` migration clarified the next real bottleneck.
+
+What the language already solves well enough:
+
+- typed records
+- record literals
+- first-class reason helpers
+- weighted score helpers
+- ordinary function reuse for many predicate-like helpers
+
+What still forces too much host-side policy wiring:
+
+- configuration access
+- mode/profile overlays
+- threshold selection from strategy config
+- temporal confirmation and cooldown semantics
+
+As a result, the next implementation priority should be:
+
+1. typed config bindings
+2. declarative temporal policy support
+3. reusable predicate ergonomics where plain functions still feel too blunt
+
 ## Proposed delivery order
 
 ### Phase 1
 
 - structured step outputs
 - first-class reasons
-- reusable predicates
+- weighted score support
 
-This is the minimum needed to move entry policy and hold reasons into TupaLang.
+This is the minimum needed to move entry policy, hold reasons, and scoring models into TupaLang.
 
 ### Phase 2
 
-- weighted score support
+- typed config bindings
 
-This enables declarative `position_health_score`.
+This enables production strategies such as ViperTrade to read thresholds and profile overlays declaratively.
 
 ### Phase 3
 
 - declarative temporal policy support
 
 This enables signal confirmation, thesis persistence windows, and cooldown semantics.
+
+### Phase 4
+
+- reusable predicate ergonomics
+
+Named predicate helpers are still useful, but ViperTrade showed that ordinary functions already cover part of this need today.
 
 ## Expected impact
 

--- a/docs/es/releases/rfc_v0.8.1_trading_strategy_support.md
+++ b/docs/es/releases/rfc_v0.8.1_trading_strategy_support.md
@@ -17,6 +17,7 @@ Esta RFC propone un tema de release acotado y pragmatico:
 - salidas estructuradas por step
 - `reason` como concepto de primera clase
 - predicados reutilizables
+- bindings tipados para configuracion
 - soporte para score ponderado
 - soporte declarativo para politicas temporales
 
@@ -47,6 +48,7 @@ La `0.8.1` debe hacer que TupaLang sea materialmente mejor para sistemas de estr
 - Permitir que los steps devuelvan resultados estructurados tipados, en lugar de solo valores primitivos.
 - Permitir que las reglas de estrategia emitan reasons legibles por maquina directamente.
 - Permitir composicion de politicas con predicados reutilizables.
+- Permitir que las politicas de estrategia lean configuracion de runtime tipada sin empujar toda la semantica al host.
 - Permitir scores ponderados de forma declarativa.
 - Permitir describir politicas temporales sin incrustar toda la semantica en el host.
 
@@ -131,7 +133,25 @@ Capacidades deseadas:
 - clamp/rango
 - comparacion con thresholds
 
-### 5. Soporte declarativo para politicas temporales
+### 5. Bindings tipados para configuracion
+
+Soportar acceso tipado a valores de configuracion provistos por el host y usados por sistemas de estrategia en produccion.
+
+Casos de uso ilustrativos:
+
+- thresholds por simbolo
+- overlays por modo
+- parametros de trailing
+- thresholds de confirmacion
+- thresholds de filtros macro
+
+Capacidades deseadas:
+
+- lecturas tipadas desde un objeto de configuracion provisto por el host
+- defaults explicitos o reglas claras de fallback
+- validacion de shape antes de la ejecucion del runtime
+
+### 6. Soporte declarativo para politicas temporales
 
 Soportar semanticas que dependen de persistencia a lo largo de ciclos de evaluacion.
 
@@ -162,27 +182,58 @@ Eso dejaria a Rust enfocado en las responsabilidades correctas:
 - transporte de eventos
 - plumbing de riesgo
 
+## Refinamiento de prioridad despues de la integracion con ViperTrade
+
+La migracion `0.8.1` de ViperTrade dejo claro el siguiente cuello de botella real.
+
+Lo que el lenguaje ya resuelve lo suficientemente bien:
+
+- records tipados
+- record literals
+- helpers de `reason`
+- helpers de score ponderado
+- reutilizacion mediante funciones normales para buena parte de los helpers tipo predicado
+
+Lo que todavia fuerza demasiado wiring del lado del host:
+
+- acceso a configuracion
+- overlays de modo/perfil
+- seleccion de thresholds desde la configuracion de la estrategia
+- semantica temporal de confirmacion y cooldown
+
+Como resultado, la siguiente prioridad de implementacion deberia ser:
+
+1. bindings tipados para configuracion
+2. soporte declarativo para politicas temporales
+3. mejor ergonomia para predicados reutilizables cuando las funciones comunes sigan siendo insuficientes
+
 ## Orden de entrega propuesta
 
 ### Fase 1
 
 - salidas estructuradas por step
 - `reason` de primera clase
-- predicados reutilizables
+- soporte para score ponderado
 
-Este es el minimo necesario para mover entry policy y hold reasons a TupaLang.
+Este es el minimo necesario para mover politica de entrada, reasons de `HOLD` y modelos de score a TupaLang.
 
 ### Fase 2
 
-- soporte para score ponderado
+- bindings tipados para configuracion
 
-Esto habilita un `position_health_score` declarativo.
+Esto habilita estrategias de produccion como ViperTrade a leer thresholds y overlays de perfil de forma declarativa.
 
 ### Fase 3
 
 - soporte declarativo para politicas temporales
 
 Esto habilita confirmacion de senal, ventanas de persistencia de tesis y semantica de cooldown.
+
+### Fase 4
+
+- ergonomia para predicados reutilizables
+
+Los predicados con nombre siguen siendo utiles, pero ViperTrade mostro que las funciones normales ya cubren parte de esa necesidad hoy.
 
 ## Impacto esperado
 

--- a/docs/pt-br/releases/rfc_v0.8.1_trading_strategy_support.md
+++ b/docs/pt-br/releases/rfc_v0.8.1_trading_strategy_support.md
@@ -17,6 +17,7 @@ Esta RFC propõe um tema de release objetivo:
 - outputs estruturados por step
 - `reason` como conceito de primeira classe
 - predicados reutilizáveis
+- bindings tipados para configuração
 - suporte a score ponderado
 - suporte declarativo a políticas temporais
 
@@ -47,6 +48,7 @@ A `0.8.1` deve tornar o TupaLang materialmente melhor para sistemas de estratég
 - Permitir que steps retornem resultados estruturados tipados, em vez de apenas valores primitivos.
 - Permitir que regras de estratégia emitam reasons legíveis por máquina diretamente.
 - Permitir composição de políticas com predicados reutilizáveis.
+- Permitir que políticas de estratégia leiam configuração de runtime tipada sem empurrar toda a semântica para o host.
 - Permitir scores ponderados de forma declarativa.
 - Permitir descrever políticas temporais sem embutir toda a semântica no host.
 
@@ -131,7 +133,25 @@ Capacidades desejadas:
 - clamp/faixa
 - comparação com thresholds
 
-### 5. Suporte declarativo a politicas temporais
+### 5. Bindings tipados para configuração
+
+Suportar acesso tipado a valores de configuração fornecidos pelo host e usados por sistemas de estratégia em produção.
+
+Casos de uso ilustrativos:
+
+- thresholds por símbolo
+- overlays por modo
+- parâmetros de trailing
+- thresholds de confirmação
+- thresholds de filtros macro
+
+Capacidades desejadas:
+
+- leituras tipadas de um objeto de configuração fornecido pelo host
+- defaults explícitos ou regras claras de fallback
+- validação de shape antes da execução do runtime
+
+### 6. Suporte declarativo a politicas temporais
 
 Suportar semânticas que dependem de persistência por ciclos de avaliação.
 
@@ -162,27 +182,58 @@ Assim o Rust fica concentrado no papel correto:
 - transporte de eventos
 - plumbing de risco
 
+## Refinamento de prioridade após a integração com o ViperTrade
+
+A migração `0.8.1` do ViperTrade deixou o próximo gargalo bem claro.
+
+O que a linguagem já resolve bem o suficiente:
+
+- records tipados
+- record literals
+- helpers de `reason`
+- helpers de score ponderado
+- reutilização via funções normais para boa parte dos helpers tipo predicado
+
+O que ainda força wiring excessivo no host:
+
+- acesso a configuração
+- overlays de modo/perfil
+- seleção de thresholds a partir da configuração da estratégia
+- semântica temporal de confirmação e cooldown
+
+Como resultado, a próxima prioridade de implementação deveria ser:
+
+1. bindings tipados para configuração
+2. suporte declarativo a políticas temporais
+3. ergonomia melhor para predicados reutilizáveis quando funções comuns ainda forem insuficientes
+
 ## Ordem de entrega proposta
 
 ### Fase 1
 
 - outputs estruturados por step
 - `reason` de primeira classe
-- predicados reutilizáveis
+- suporte a score ponderado
 
-Esse é o mínimo necessário para mover entry policy e hold reasons para o TupaLang.
+Esse é o mínimo necessário para mover política de entrada, reasons de `HOLD` e modelos de score para o TupaLang.
 
 ### Fase 2
 
-- suporte a score ponderado
+- bindings tipados para configuração
 
-Isso habilita `position_health_score` declarativo.
+Isso habilita estratégias de produção como o ViperTrade a ler thresholds e overlays de perfil de forma declarativa.
 
 ### Fase 3
 
 - suporte declarativo a políticas temporais
 
 Isso habilita confirmação de sinal, janelas de persistência de tese e semântica de cooldown.
+
+### Fase 4
+
+- ergonomia para predicados reutilizáveis
+
+Predicados nomeados continuam úteis, mas o ViperTrade mostrou que funções normais já cobrem parte dessa necessidade hoje.
 
 ## Impacto esperado
 


### PR DESCRIPTION
## Summary
- refine the v0.8.1 RFC after the ViperTrade integration work
- record that typed config bindings are now the next most practical priority
- move temporal policy support ahead of predicate ergonomics in the delivery order

## Why
- ViperTrade already proved out records, reason helpers, weighted score helpers, and ordinary function reuse
- the next real bottlenecks are host-side config wiring and temporal policy semantics

## Validation
- git diff --check