### PR TITLE
docs: add typed config input pattern for trading pipelines

### DIFF
--- a/crates/tupa-runtime/src/lib.rs
+++ b/crates/tupa-runtime/src/lib.rs
@@ -1054,4 +1054,101 @@ mod tests {
             .expect_err("output schema should fail");
         assert!(matches!(err, RuntimeError::ValidationError(_)));
     }
+
+    #[tokio::test]
+    async fn test_runtime_accepts_nested_config_input_schema() {
+        use tupa_codegen::execution_plan::StepPlan;
+
+        let runtime = Runtime::new();
+        runtime.register_step("noop", Ok);
+
+        let plan = ExecutionPlan {
+            name: "config_input".into(),
+            version: "1.0".into(),
+            seed: None,
+            input_schema: TypeSchema {
+                kind: "object".into(),
+                elem: None,
+                fields: Some(HashMap::from([
+                    (
+                        "symbol".into(),
+                        TypeSchema {
+                            kind: "string".into(),
+                            elem: None,
+                            fields: None,
+                            len: None,
+                            name: None,
+                            tensor_shape: None,
+                            tensor_dtype: None,
+                        },
+                    ),
+                    (
+                        "config".into(),
+                        TypeSchema {
+                            kind: "object".into(),
+                            elem: None,
+                            fields: Some(HashMap::from([(
+                                "entry".into(),
+                                TypeSchema {
+                                    kind: "object".into(),
+                                    elem: None,
+                                    fields: Some(HashMap::from([(
+                                        "max_spread_pct".into(),
+                                        TypeSchema {
+                                            kind: "f64".into(),
+                                            elem: None,
+                                            fields: None,
+                                            len: None,
+                                            name: None,
+                                            tensor_shape: None,
+                                            tensor_dtype: None,
+                                        },
+                                    )])),
+                                    len: None,
+                                    name: None,
+                                    tensor_shape: None,
+                                    tensor_dtype: None,
+                                },
+                            )])),
+                            len: None,
+                            name: None,
+                            tensor_shape: None,
+                            tensor_dtype: None,
+                        },
+                    ),
+                ])),
+                len: None,
+                name: None,
+                tensor_shape: None,
+                tensor_dtype: None,
+            },
+            output_schema: None,
+            steps: vec![StepPlan {
+                name: "result".into(),
+                function_ref: "noop".into(),
+                effects: vec![],
+            }],
+            constraints: vec![],
+            metrics: HashMap::new(),
+            metric_plans: vec![],
+        };
+
+        let result = runtime
+            .run_pipeline_async(
+                &plan,
+                json!({
+                    "symbol": "DOGEUSDT",
+                    "config": {
+                        "entry": {
+                            "max_spread_pct": 0.001
+                        }
+                    }
+                }),
+            )
+            .await
+            .expect("nested config input should pass");
+
+        assert_eq!(result["symbol"], json!("DOGEUSDT"));
+        assert_eq!(result["result"]["config"]["entry"]["max_spread_pct"], json!(0.001));
+    }
 }

--- a/crates/tupa-runtime/src/lib.rs
+++ b/crates/tupa-runtime/src/lib.rs
@@ -1149,6 +1149,9 @@ mod tests {
             .expect("nested config input should pass");
 
         assert_eq!(result["symbol"], json!("DOGEUSDT"));
-        assert_eq!(result["result"]["config"]["entry"]["max_spread_pct"], json!(0.001));
+        assert_eq!(
+            result["result"]["config"]["entry"]["max_spread_pct"],
+            json!(0.001)
+        );
     }
 }

--- a/docs/en/features/trading_support.md
+++ b/docs/en/features/trading_support.md
@@ -55,6 +55,41 @@ Compliance-ready logging using the `tracing` crate.
   - `trade_blocked_by_risk` (when constraints fail)
   - `circuit_breaker_tripped`
 
+### 5. Typed host-provided config via structured input
+
+Tupã already supports a practical config-binding pattern for production strategy systems:
+
+- declare pipeline input as a nested record
+- pass market data and config in the same typed input object
+- use ordinary field access inside policy functions
+
+This is already enough for many strategy cases such as:
+
+- per-symbol thresholds
+- mode/profile overlays
+- trailing parameters
+- confirmation thresholds
+
+Example shape:
+
+```text
+input: {
+  symbol: string,
+  signal: { spread_pct: f64, trend_score: f64 },
+  config: {
+    entry: {
+      max_spread_pct: f64,
+      min_trend_score_long: f64
+    }
+  }
+}
+```
+
+See:
+
+- `examples/pipeline/config_driven_strategy.tp`
+- `examples/pipeline/config_driven_strategy.json`
+
 ## Usage Example
 
 ```rust

--- a/examples/pipeline/README.md
+++ b/examples/pipeline/README.md
@@ -4,6 +4,7 @@
 - credit_decision.tp: credit decision with 3 constraints.
 - loan_underwriting.tp: underwriting with risk metrics.
 - customer_churn.tp: churn and retention metrics.
+- config_driven_strategy.tp: typed nested input pattern for host-provided strategy config.
 
 ## Run
 
@@ -17,4 +18,14 @@ Generate plan and run from plan:
 ```bash
 tupa codegen --plan-only examples/pipeline/fraud_complete.tp
 tupa run --plan fraud_complete.plan.json --pipeline=FraudDetection --input examples/pipeline/tx.json
+```
+
+Config-driven strategy example:
+
+```bash
+tupa check examples/pipeline/config_driven_strategy.tp
+tupa run \
+  --pipeline=ConfigDrivenStrategy \
+  --input examples/pipeline/config_driven_strategy.json \
+  examples/pipeline/config_driven_strategy.tp
 ```

--- a/examples/pipeline/config_driven_strategy.json
+++ b/examples/pipeline/config_driven_strategy.json
@@ -1,0 +1,13 @@
+{
+  "symbol": "DOGEUSDT",
+  "signal": {
+    "spread_pct": 0.0005,
+    "trend_score": 0.42
+  },
+  "config": {
+    "entry": {
+      "max_spread_pct": 0.001,
+      "min_trend_score_long": 0.30
+    }
+  }
+}

--- a/examples/pipeline/config_driven_strategy.tp
+++ b/examples/pipeline/config_driven_strategy.tp
@@ -1,0 +1,69 @@
+fn passes_spread_limit(
+  input: {
+    symbol: string,
+    signal: {
+      spread_pct: f64,
+      trend_score: f64
+    },
+    config: {
+      entry: {
+        max_spread_pct: f64,
+        min_trend_score_long: f64
+      }
+    }
+  }
+): {
+  passed: bool,
+  severity: string,
+  reason: string
+} {
+  if input.signal.spread_pct <= input.config.entry.max_spread_pct {
+    return pass("spread_within_limit");
+  }
+  return fail("spread_above_limit");
+}
+
+fn score_entry(
+  input: {
+    symbol: string,
+    signal: {
+      spread_pct: f64,
+      trend_score: f64
+    },
+    config: {
+      entry: {
+        max_spread_pct: f64,
+        min_trend_score_long: f64
+      }
+    }
+  }
+): {
+  score: f64,
+  weight: f64,
+  reason: string
+} {
+  if input.signal.trend_score >= input.config.entry.min_trend_score_long {
+    return weighted(1.0, 100.0, "trend_score_ok");
+  }
+  return weighted(0.0, 100.0, "trend_score_low");
+}
+
+pipeline ConfigDrivenStrategy @deterministic(seed=42) {
+  input: {
+    symbol: string,
+    signal: {
+      spread_pct: f64,
+      trend_score: f64
+    },
+    config: {
+      entry: {
+        max_spread_pct: f64,
+        min_trend_score_long: f64
+      }
+    }
+  },
+  steps: [
+    step("spread_gate") { passes_spread_limit(input) },
+    step("entry_score") { score_entry(input) }
+  ],
+}


### PR DESCRIPTION
## Summary
- add a config-driven strategy example using nested typed input records
- document the host-provided typed config pattern for trading pipelines
- add a runtime test proving nested config input schema validation

## Why
- ViperTrade showed that typed config access is a real priority
- this proves a practical pattern already works without adding new core syntax first

## Validation
- `docker run --rm -v /home/paiva/teste/tupalang:/workspace -w /workspace tupalang-ci-local:test cargo test -p tupa-runtime test_runtime_accepts_nested_config_input_schema --locked`
- `docker run --rm -v /home/paiva/teste/tupalang:/workspace -w /workspace tupalang-ci-local:test cargo run -p tupa-cli -- check examples/pipeline/config_driven_strategy.tp`