### PR TITLE
feat: add temporal policy builtins

### DIFF
--- a/crates/tupa-typecheck/src/lib.rs
+++ b/crates/tupa-typecheck/src/lib.rs
@@ -3080,6 +3080,75 @@ fn builtin_score_function() -> FuncSig {
     }
 }
 
+fn builtin_confirm_return() -> TypeSig {
+    TypeSig {
+        ty: Ty::Record(vec![
+            ("passed".into(), Ty::Bool),
+            ("pending".into(), Ty::Bool),
+            ("remaining_hits".into(), Ty::I64),
+            ("reason".into(), Ty::String),
+        ]),
+        constraints: None,
+    }
+}
+
+fn builtin_confirm_function() -> FuncSig {
+    FuncSig {
+        params: vec![
+            TypeSig {
+                ty: Ty::Bool,
+                constraints: None,
+            },
+            TypeSig {
+                ty: Ty::I64,
+                constraints: None,
+            },
+            TypeSig {
+                ty: Ty::I64,
+                constraints: None,
+            },
+            TypeSig {
+                ty: Ty::String,
+                constraints: None,
+            },
+        ],
+        ret: builtin_confirm_return(),
+        effects: EffectSet::default(),
+    }
+}
+
+fn builtin_cooldown_return() -> TypeSig {
+    TypeSig {
+        ty: Ty::Record(vec![
+            ("blocked".into(), Ty::Bool),
+            ("remaining_ticks".into(), Ty::I64),
+            ("reason".into(), Ty::String),
+        ]),
+        constraints: None,
+    }
+}
+
+fn builtin_cooldown_function() -> FuncSig {
+    FuncSig {
+        params: vec![
+            TypeSig {
+                ty: Ty::Bool,
+                constraints: None,
+            },
+            TypeSig {
+                ty: Ty::I64,
+                constraints: None,
+            },
+            TypeSig {
+                ty: Ty::String,
+                constraints: None,
+            },
+        ],
+        ret: builtin_cooldown_return(),
+        effects: EffectSet::default(),
+    }
+}
+
 fn builtin_weighted_function() -> FuncSig {
     FuncSig {
         params: vec![
@@ -3108,6 +3177,8 @@ fn builtin_functions() -> HashMap<String, FuncSig> {
         ("warn".into(), builtin_reason_function(false, "warn")),
         ("score".into(), builtin_score_function()),
         ("weighted".into(), builtin_weighted_function()),
+        ("confirm".into(), builtin_confirm_function()),
+        ("cooldown".into(), builtin_cooldown_function()),
     ])
 }
 
@@ -3735,6 +3806,62 @@ mod tests {
             Err(TypeError::Mismatch {
                 expected: Ty::F64,
                 found: Ty::Bool,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn typecheck_confirm_builtin_assignment() {
+        let program = parse_program(
+            "fn main() { let gate: { passed: bool, pending: bool, remaining_hits: i64, reason: string } = confirm(true, 2, 3, \"signal_confirmation\"); }",
+        )
+        .unwrap();
+        assert!(typecheck_program(&program).is_ok());
+    }
+
+    #[test]
+    fn typecheck_confirm_builtin_field_access() {
+        let program = parse_program(
+            "fn remaining(): i64 { let gate = confirm(true, 2, 3, \"signal_confirmation\"); return gate.remaining_hits; }",
+        )
+        .unwrap();
+        assert!(typecheck_program(&program).is_ok());
+    }
+
+    #[test]
+    fn typecheck_confirm_builtin_wrong_arg_type() {
+        let program =
+            parse_program("fn main() { let gate = confirm(true, 2.0, 3, \"signal\"); }").unwrap();
+        assert!(matches!(
+            typecheck_program(&program),
+            Err(TypeError::Mismatch {
+                expected: Ty::I64,
+                found: Ty::F64,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn typecheck_cooldown_builtin_assignment() {
+        let program = parse_program(
+            "fn main() { let gate: { blocked: bool, remaining_ticks: i64, reason: string } = cooldown(true, 4, \"stop_loss_cooldown\"); }",
+        )
+        .unwrap();
+        assert!(typecheck_program(&program).is_ok());
+    }
+
+    #[test]
+    fn typecheck_cooldown_builtin_wrong_arity() {
+        let program =
+            parse_program("fn main() { let gate = cooldown(true, 4, \"cooldown\", \"extra\"); }")
+                .unwrap();
+        assert!(matches!(
+            typecheck_program(&program),
+            Err(TypeError::ArityMismatch {
+                expected: 3,
+                found: 4,
                 ..
             })
         ));

--- a/docs/en/features/trading_support.md
+++ b/docs/en/features/trading_support.md
@@ -90,6 +90,47 @@ See:
 - `examples/pipeline/config_driven_strategy.tp`
 - `examples/pipeline/config_driven_strategy.json`
 
+### 6. Declarative temporal policy via host-provided state
+
+Tupã can already model a first slice of temporal strategy policy without moving host state into the
+language runtime:
+
+- the host keeps counters and timers
+- the pipeline receives that temporal state as structured input
+- built-ins express the policy result shape for confirmation and cooldown decisions
+
+Current built-ins:
+
+- `confirm(observed, consecutive_hits, required_hits, reason)`
+- `cooldown(active, remaining_ticks, reason)`
+
+These are designed for cases such as:
+
+- signal confirmation after `N` consecutive observations
+- stop-loss cooldown gates
+- thesis persistence thresholds driven by host-maintained counters
+
+Example shape:
+
+```text
+input: {
+  signal: {
+    observed: bool,
+    consecutive_hits: i64,
+    required_hits: i64
+  },
+  guards: {
+    cooldown_active: bool,
+    remaining_ticks: i64
+  }
+}
+```
+
+See:
+
+- `examples/pipeline/temporal_policy.tp`
+- `examples/pipeline/temporal_policy.json`
+
 ## Usage Example
 
 ```rust

--- a/docs/es/features/trading_support.md
+++ b/docs/es/features/trading_support.md
@@ -51,6 +51,82 @@ Logging listo para cumplimiento utilizando `tracing`.
   - `trade_blocked_by_risk` (cuando fallan restricciones)
   - `circuit_breaker_tripped`
 
+### 5. Config tipada provista por el host vía input estructurado
+
+Tupã ya soporta un patrón práctico de config binding para sistemas de estrategia en producción:
+
+- declarar el input del pipeline como un record anidado
+- pasar datos de mercado y config en el mismo objeto tipado
+- usar field access común dentro de funciones de policy
+
+Esto ya cubre muchos casos de estrategia, como:
+
+- thresholds por símbolo
+- overlays por modo/perfil
+- parámetros de trailing
+- thresholds de confirmación
+
+Shape de ejemplo:
+
+```text
+input: {
+  symbol: string,
+  signal: { spread_pct: f64, trend_score: f64 },
+  config: {
+    entry: {
+      max_spread_pct: f64,
+      min_trend_score_long: f64
+    }
+  }
+}
+```
+
+Ver:
+
+- `examples/pipeline/config_driven_strategy.tp`
+- `examples/pipeline/config_driven_strategy.json`
+
+### 6. Política temporal declarativa vía estado provisto por el host
+
+Tupã ya puede modelar un primer slice de política temporal sin mover el estado del host al runtime
+del lenguaje:
+
+- el host mantiene contadores y timers
+- el pipeline recibe ese estado temporal como input estructurado
+- built-ins expresan el shape del resultado para confirmación y cooldown
+
+Built-ins actuales:
+
+- `confirm(observed, consecutive_hits, required_hits, reason)`
+- `cooldown(active, remaining_ticks, reason)`
+
+Esto es útil para casos como:
+
+- confirmación de señal tras `N` observaciones consecutivas
+- cooldown después de stop loss
+- persistencia de tesis dirigida por contadores mantenidos en el host
+
+Shape de ejemplo:
+
+```text
+input: {
+  signal: {
+    observed: bool,
+    consecutive_hits: i64,
+    required_hits: i64
+  },
+  guards: {
+    cooldown_active: bool,
+    remaining_ticks: i64
+  }
+}
+```
+
+Ver:
+
+- `examples/pipeline/temporal_policy.tp`
+- `examples/pipeline/temporal_policy.json`
+
 ## Ejemplo de Uso
 
 ```rust

--- a/docs/pt-br/features/trading_support.md
+++ b/docs/pt-br/features/trading_support.md
@@ -51,6 +51,82 @@ Logging pronto para conformidade usando a crate `tracing`.
   - `trade_blocked_by_risk` (quando restrições falham)
   - `circuit_breaker_tripped`
 
+### 5. Config tipada fornecida pelo host via input estruturado
+
+O Tupã já suporta um padrão prático de config binding para sistemas de estratégia em produção:
+
+- declarar o input do pipeline como um record aninhado
+- passar dados de mercado e config no mesmo objeto tipado
+- usar field access comum dentro das funções de policy
+
+Isso já cobre muitos casos de estratégia, como:
+
+- thresholds por símbolo
+- overlays por modo/perfil
+- parâmetros de trailing
+- thresholds de confirmação
+
+Shape de exemplo:
+
+```text
+input: {
+  symbol: string,
+  signal: { spread_pct: f64, trend_score: f64 },
+  config: {
+    entry: {
+      max_spread_pct: f64,
+      min_trend_score_long: f64
+    }
+  }
+}
+```
+
+Veja:
+
+- `examples/pipeline/config_driven_strategy.tp`
+- `examples/pipeline/config_driven_strategy.json`
+
+### 6. Política temporal declarativa via estado fornecido pelo host
+
+O Tupã já consegue modelar um primeiro slice de política temporal sem mover o estado do host para
+o runtime da linguagem:
+
+- o host mantém contadores e timers
+- o pipeline recebe esse estado temporal como input estruturado
+- built-ins expressam o shape do resultado para confirmação e cooldown
+
+Built-ins atuais:
+
+- `confirm(observed, consecutive_hits, required_hits, reason)`
+- `cooldown(active, remaining_ticks, reason)`
+
+Isso é útil para casos como:
+
+- confirmação de sinal após `N` observações consecutivas
+- cooldown após stop loss
+- persistência de tese dirigida por contadores mantidos no host
+
+Shape de exemplo:
+
+```text
+input: {
+  signal: {
+    observed: bool,
+    consecutive_hits: i64,
+    required_hits: i64
+  },
+  guards: {
+    cooldown_active: bool,
+    remaining_ticks: i64
+  }
+}
+```
+
+Veja:
+
+- `examples/pipeline/temporal_policy.tp`
+- `examples/pipeline/temporal_policy.json`
+
 ## Exemplo de Uso
 
 ```rust

--- a/examples/pipeline/README.md
+++ b/examples/pipeline/README.md
@@ -5,6 +5,7 @@
 - loan_underwriting.tp: underwriting with risk metrics.
 - customer_churn.tp: churn and retention metrics.
 - config_driven_strategy.tp: typed nested input pattern for host-provided strategy config.
+- temporal_policy.tp: temporal policy pattern with host-provided confirmation and cooldown state.
 
 ## Run
 
@@ -28,4 +29,14 @@ tupa run \
   --pipeline=ConfigDrivenStrategy \
   --input examples/pipeline/config_driven_strategy.json \
   examples/pipeline/config_driven_strategy.tp
+```
+
+Temporal policy example:
+
+```bash
+tupa check examples/pipeline/temporal_policy.tp
+tupa run \
+  --pipeline=TemporalPolicySupport \
+  --input examples/pipeline/temporal_policy.json \
+  examples/pipeline/temporal_policy.tp
 ```

--- a/examples/pipeline/temporal_policy.json
+++ b/examples/pipeline/temporal_policy.json
@@ -1,0 +1,11 @@
+{
+  "signal": {
+    "observed": true,
+    "consecutive_hits": 2,
+    "required_hits": 3
+  },
+  "guards": {
+    "cooldown_active": true,
+    "remaining_ticks": 4
+  }
+}

--- a/examples/pipeline/temporal_policy.tp
+++ b/examples/pipeline/temporal_policy.tp
@@ -1,0 +1,67 @@
+fn evaluate_signal_confirmation(
+  input: {
+    signal: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    guards: {
+      cooldown_active: bool,
+      remaining_ticks: i64
+    }
+  }
+): {
+  passed: bool,
+  pending: bool,
+  remaining_hits: i64,
+  reason: string
+} {
+  return confirm(
+    input.signal.observed,
+    input.signal.consecutive_hits,
+    input.signal.required_hits,
+    "signal_confirmation"
+  );
+}
+
+fn evaluate_stop_loss_cooldown(
+  input: {
+    signal: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    guards: {
+      cooldown_active: bool,
+      remaining_ticks: i64
+    }
+  }
+): {
+  blocked: bool,
+  remaining_ticks: i64,
+  reason: string
+} {
+  return cooldown(
+    input.guards.cooldown_active,
+    input.guards.remaining_ticks,
+    "stop_loss_cooldown"
+  );
+}
+
+pipeline TemporalPolicySupport @deterministic(seed=42) {
+  input: {
+    signal: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    guards: {
+      cooldown_active: bool,
+      remaining_ticks: i64
+    }
+  },
+  steps: [
+    step("signal_confirmation") { evaluate_signal_confirmation(input) },
+    step("cooldown_guard") { evaluate_stop_loss_cooldown(input) }
+  ],
+}


### PR DESCRIPTION
## Summary
- add typed temporal policy builtins for confirmation and cooldown
- document host-provided temporal state as the current pragmatic model
- add a temporal strategy example and typechecker coverage

## Validation
- cargo test -p tupa-typecheck --locked
- cargo run -p tupa-cli -- check examples/pipeline/temporal_policy.tp
