### PR TITLE
docs: prepare TupaLang 0.8.1 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It bridges static safety and dynamic runtime flexibility for trading workflows, 
 
 > **Tupã** (Guaraní mythology): the spirit of thunder and enlightenment.
 
-## Distribution Model (v0.8.0-rc)
+## Distribution Model (v0.8.1)
 
 Tupã follows a **hybrid distribution** strategy:
 

--- a/docs/en/releases/changelog.md
+++ b/docs/en/releases/changelog.md
@@ -4,45 +4,54 @@
 
 This document records relevant changes per version.
 
-## 0.8.1 (planned)
+## 0.8.1 (2026-03-21)
 
-- Planned release theme: production strategy support for real policy systems.
-- Planned scope:
-  - structured step outputs
-  - first-class policy reasons
-  - reusable predicates
-  - weighted score support
-  - declarative temporal policy support
+- Release theme: production strategy support for real policy systems.
 - Planning reference:
   - `docs/en/releases/rfc_v0.8.1_trading_strategy_support.md`
 
 ### Delivered Scope
 
-- Planned language and runtime support for production strategy systems.
-- Planned improvements for declarative strategy modeling:
+- Language and runtime support for production strategy systems.
+- Declarative strategy modeling improvements:
   - structured step outputs
   - first-class policy reasons
-  - reusable predicates
   - weighted score support
+  - typed config input pattern via nested records
   - declarative temporal policy support
+- Type system and runtime slices delivered:
+  - record types
+  - record literals
+  - typed field access
+  - runtime schema validation for structured inputs and outputs
+- Temporal policy builtins delivered:
+  - `confirm(...)`
+  - `cooldown(...)`
 
 ### Engineering and CI Completed
 
 - RFC added in English, PT-BR, and Spanish to preserve docs parity.
-- Roadmap, changelog, and docs indices updated to point to the `0.8.1` planning track.
+- Docs parity maintained across the release planning and implementation cycle.
+- Containerized local CI added to reduce drift between host environments and GitHub Actions.
+- Trading support docs and examples expanded with:
+  - config-driven pipeline example
+  - temporal policy example
+- ViperTrade integration used as a functional proving ground for the 0.8.1 slices.
 
 ### Validation Snapshot (workspace)
 
-- Current status: planning RFC only, no implementation merged yet.
-- Validation expectation before release:
+- Release-prep status: implementation merged on `main`, awaiting tag and published binary artifacts.
+- Validation status:
   - docs parity green
   - markdownlint green
-  - CI green for language and runtime changes included in the final release scope
+  - CI green for merged language/runtime changes
+  - ViperTrade local CI green against the current `main`
 
 ### Technical Debt
 
-- The RFC defines planning direction, but no implementation slices are committed yet.
-- Final release scope still depends on implementation cost and review outcomes.
+- Typed config access is solved pragmatically through structured `input`, not dedicated config-binding syntax.
+- Temporal policy remains declarative at the policy layer; host-managed state still lives outside the language runtime.
+- Release automation is ready, but the public `v0.8.1` tag and binary artifacts have not been cut yet.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/en/releases/roadmap.md
+++ b/docs/en/releases/roadmap.md
@@ -6,11 +6,9 @@ This document summarizes the project evolution plan.
 
 ## Short Term
 
-- v0.8.1: strengthen trading strategy support for production policy systems.
-- Add structured step outputs and first-class policy reasons.
-- Add reusable predicates for strategy composition.
-- Add weighted score support for policy evaluation.
-- Add declarative temporal policy primitives for confirmation and cooldown semantics.
+- Cut and publish the `v0.8.1` release artifacts and crates.
+- Validate ViperTrade against the official `v0.8.1` standalone CLI release.
+- Refine reusable predicate ergonomics on top of the new policy-modeling primitives.
 
 - Consolidate SPEC v0.1 (fine-tuning and validated examples).
 - Improve the typechecker (constraints and diagnostics).

--- a/docs/es/releases/changelog.md
+++ b/docs/es/releases/changelog.md
@@ -5,45 +5,54 @@
 
 Registrar cambios relevantes por versión.
 
-## 0.8.1 (planned)
+## 0.8.1 (2026-03-21)
 
-- Tema planificado del release: soporte para estrategias de produccion en sistemas reales de politica.
-- Alcance planificado:
-  - salidas estructuradas por step
-  - `reason` de primera clase
-  - predicados reutilizables
-  - soporte para score ponderado
-  - soporte declarativo para politicas temporales
+- Tema del release: soporte para estrategias de produccion en sistemas reales de politica.
 - Referencia de planificacion:
   - `docs/es/releases/rfc_v0.8.1_trading_strategy_support.md`
 
 ### Alcance Entregado
 
-- Soporte planificado de lenguaje y runtime para sistemas de estrategia de produccion.
-- Mejoras planificadas para modelado declarativo de estrategia:
+- Soporte de lenguaje y runtime para sistemas de estrategia de produccion.
+- Mejoras para modelado declarativo de estrategia:
   - salidas estructuradas por step
   - `reason` de primera clase
-  - predicados reutilizables
   - soporte para score ponderado
+  - patron de input tipado para configuracion con records anidados
   - soporte declarativo para politicas temporales
+- Slices de type system y runtime entregados:
+  - record types
+  - record literals
+  - acceso tipado a campos
+  - validacion de schema en runtime para inputs y outputs estructurados
+- Builtins temporales entregados:
+  - `confirm(...)`
+  - `cooldown(...)`
 
 ### Ingeniería y CI Completados
 
 - RFC agregada en ingles, PT-BR y espanol para preservar la paridad de docs.
-- Hoja de ruta, changelog e indices de docs actualizados para apuntar al plan de `0.8.1`.
+- Paridad de docs mantenida durante el ciclo de planificacion e implementacion.
+- CI local containerizado agregado para reducir drift entre host y GitHub Actions.
+- Docs y ejemplos de trading ampliados con:
+  - ejemplo de pipeline guiado por configuracion
+  - ejemplo de politica temporal
+- La integracion con ViperTrade se uso como prueba funcional de los slices de `0.8.1`.
 
 ### Snapshot de Validación del Workspace
 
-- Estado actual: solo RFC de planificacion, sin implementacion mergeada todavia.
-- Expectativa de validacion antes del release:
+- Estado de preparacion de release: implementacion mergeada en `main`, a la espera del tag y de los binarios publicos.
+- Estado de validacion:
   - docs parity en verde
   - markdownlint en verde
-  - CI en verde para los cambios de lenguaje y runtime incluidos en el alcance final del release
+  - CI en verde para los cambios de lenguaje y runtime mergeados
+  - CI local de ViperTrade en verde contra el `main` actual
 
 ### Deuda Técnica
 
-- La RFC define la direccion de planificacion, pero todavia no hay slices de implementacion commiteados.
-- El alcance final del release todavia depende del costo de implementacion y del resultado de las revisiones.
+- El acceso tipado a configuracion esta resuelto de forma pragmatica mediante `input` estructurado, no por sintaxis dedicada.
+- La politica temporal sigue siendo declarativa en la capa de policy; el estado del host sigue fuera del runtime del lenguaje.
+- La automatizacion de release esta lista, pero el tag publico `v0.8.1` y los binarios todavia no se han publicado.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/es/releases/roadmap.md
+++ b/docs/es/releases/roadmap.md
@@ -6,11 +6,9 @@ Resumir el plan de evolución del proyecto.
 
 ## Corto plazo
 
-- v0.8.1: fortalecer el soporte para estrategias de trading en sistemas reales de politica.
-- Agregar salidas estructuradas por step y `reason` de primera clase.
-- Agregar predicados reutilizables para composicion de estrategia.
-- Agregar soporte para score ponderado en evaluacion de politica.
-- Agregar primitivas declarativas para confirmacion y cooldown.
+- Cortar y publicar los artefactos y crates del release `v0.8.1`.
+- Validar ViperTrade contra la release oficial del CLI standalone `v0.8.1`.
+- Refinar la ergonomia de predicados reutilizables sobre las nuevas primitivas de policy.
 
 - Consolidar la SPEC v0.1 (ajustes finos y ejemplos validados).
 - Mejorar el typechecker (restricciones y diagnósticos).

--- a/docs/pt-br/releases/changelog.md
+++ b/docs/pt-br/releases/changelog.md
@@ -5,45 +5,54 @@
 
 Registrar mudanças relevantes por versão.
 
-## 0.8.1 (planned)
+## 0.8.1 (2026-03-21)
 
-- Tema planejado do release: suporte a estratégias de produção para sistemas reais de política.
-- Escopo planejado:
-  - outputs estruturados por step
-  - `reason` de primeira classe
-  - predicados reutilizáveis
-  - suporte a score ponderado
-  - suporte declarativo a políticas temporais
+- Tema do release: suporte a estratégias de produção para sistemas reais de política.
 - Referência de planejamento:
   - `docs/pt-br/releases/rfc_v0.8.1_trading_strategy_support.md`
 
 ### Escopo Entregue
 
-- Suporte planejado de linguagem e runtime para sistemas de estratégia de produção.
-- Melhorias planejadas para modelagem declarativa de estratégia:
+- Suporte de linguagem e runtime para sistemas de estratégia de produção.
+- Melhorias para modelagem declarativa de estratégia:
   - outputs estruturados por step
   - `reason` de primeira classe
-  - predicados reutilizáveis
   - suporte a score ponderado
+  - padrão de input tipado para configuração com records aninhados
   - suporte declarativo a políticas temporais
+- Slices de type system e runtime entregues:
+  - record types
+  - record literals
+  - acesso tipado a campos
+  - validação de schema no runtime para inputs e outputs estruturados
+- Builtins temporais entregues:
+  - `confirm(...)`
+  - `cooldown(...)`
 
 ### Engenharia e CI Entregues
 
 - RFC adicionada em inglês, PT-BR e espanhol para preservar a paridade de docs.
-- Roadmap, changelog e índices de docs atualizados para apontar para a trilha de planejamento da `0.8.1`.
+- Paridade de docs mantida durante o ciclo de planejamento e implementação.
+- CI local containerizado adicionado para reduzir drift entre host e GitHub Actions.
+- Docs e exemplos de trading expandidos com:
+  - exemplo de pipeline guiado por configuração
+  - exemplo de política temporal
+- A integração com o ViperTrade foi usada como prova funcional dos slices da `0.8.1`.
 
 ### Snapshot de Validação do Workspace
 
-- Status atual: apenas RFC de planejamento, sem implementação mergeada ainda.
-- Expectativa de validação antes do release:
+- Status de preparação de release: implementação mergeada na `main`, aguardando tag e binários públicos.
+- Status de validação:
   - docs parity verde
   - markdownlint verde
-  - CI verde para as mudanças de linguagem e runtime incluídas no escopo final do release
+  - CI verde para as mudanças de linguagem e runtime mergeadas
+  - CI local do ViperTrade verde contra a `main` atual
 
 ### Débito Técnico
 
-- A RFC define a direção de planejamento, mas ainda não há slices de implementação commitados.
-- O escopo final do release ainda depende do custo de implementação e do resultado das revisões.
+- O acesso tipado à configuração foi resolvido pragmaticamente por meio de `input` estruturado, não por sintaxe dedicada.
+- A política temporal continua declarativa na camada de policy; o estado do host continua fora do runtime da linguagem.
+- A automação de release está pronta, mas a tag pública `v0.8.1` e os binários ainda não foram publicados.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/pt-br/releases/roadmap.md
+++ b/docs/pt-br/releases/roadmap.md
@@ -6,11 +6,9 @@ Resumir o plano de evolução do projeto.
 
 ## Curto prazo
 
-- v0.8.1: fortalecer o suporte a estratégias de trading para sistemas reais de política.
-- Adicionar outputs estruturados por step e `reason` de primeira classe.
-- Adicionar predicados reutilizáveis para composição de estratégia.
-- Adicionar suporte a score ponderado para avaliação de política.
-- Adicionar primitivas declarativas para confirmação e cooldown.
+- Cortar e publicar os artefatos e crates do release `v0.8.1`.
+- Validar o ViperTrade contra a release oficial do CLI standalone `v0.8.1`.
+- Refinar a ergonomia de predicados reutilizáveis sobre as novas primitivas de policy.
 
 - Consolidar a SPEC v0.1 (ajustes finos e exemplos validados).
 - Melhorar o typechecker (restrições e diagnósticos).


### PR DESCRIPTION
## Summary
- mark the 0.8.1 changelog entry as release-ready instead of planning-only
- record the actual delivered scope for policy modeling and temporal support
- update the short-term roadmap to focus on cutting and validating the 0.8.1 release
- align the README distribution model heading with 0.8.1

## Validation
- CI_LOCAL_SKIP_BUILD=1 IMAGE_NAME=tupalang-ci-local:test ./scripts/ci-local-container.sh
