### PR TITLE
docs: align crate and feature docs with 0.8.1

### DIFF
--- a/crates/tupa-cli/README.md
+++ b/crates/tupa-cli/README.md
@@ -5,7 +5,7 @@ Command-line interface for TupaLang.
 ## Install
 
 ```bash
-cargo install tupa-cli
+cargo install --locked tupa-cli
 ```
 
 ## Basic commands

--- a/crates/tupa-codegen/README.md
+++ b/crates/tupa-codegen/README.md
@@ -7,14 +7,18 @@ Transforms typed AST into executable artifacts (stubs and execution plans).
 ```rust
 use tupa_parser::parse_program;
 use tupa_codegen::execution_plan::codegen_pipeline;
+use tupa_typecheck::typecheck_program;
 
 let src = r#"pipeline P { input: string, steps: [], output: string }"#;
 let program = parse_program(src)?;
+typecheck_program(&program)?;
 let pipeline = program.items.iter().find_map(|i| match i { tupa_parser::Item::Pipeline(p) => Some(p), _ => None }).unwrap();
 let plan_json = codegen_pipeline("demo", pipeline, &program)?;
 println!("{}", plan_json);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+Run `tupa-typecheck` before generating plans so the execution plan is produced from a validated program.
 
 ## Crate
 

--- a/crates/tupa-pyffi/README.md
+++ b/crates/tupa-pyffi/README.md
@@ -8,9 +8,13 @@ Python FFI bridge for calling external Python functions from Tupa runtime.
 use serde_json::json;
 use tupa_pyffi::call_python_function;
 
-let _ = call_python_function("module", "func", json!({"x": 1}));
+let result = call_python_function("math", "sqrt", json!(16.0))?;
+assert_eq!(result, json!(4.0));
+# Ok::<(), String>(())
 ```
 
 ## Notes
 
 - Requires Python runtime/toolchain in build or runtime environment.
+- Calls a Python function with a single JSON-like argument and converts the return value back to `serde_json::Value`.
+- The target module must be importable from the active Python environment.

--- a/crates/tupa-runtime/README.md
+++ b/crates/tupa-runtime/README.md
@@ -6,14 +6,44 @@ Execution engine for TupaLang pipelines.
 
 ```rust
 use serde_json::json;
+use tupa_codegen::execution_plan::{ExecutionPlan, TypeSchema, StepPlan};
 use tupa_runtime::Runtime;
 
 let runtime = Runtime::new();
 runtime.register_step("demo::step_echo", |state| Ok(state));
-let _ = json!({"ok": true});
+
+let plan = ExecutionPlan {
+    name: "demo".into(),
+    version: "0.8.1".into(),
+    seed: None,
+    input_schema: TypeSchema {
+        kind: "string".into(),
+        elem: None,
+        fields: None,
+        len: None,
+        name: None,
+        tensor_shape: None,
+        tensor_dtype: None,
+    },
+    output_schema: None,
+    steps: vec![StepPlan {
+        name: "echo".into(),
+        function_ref: "demo::step_echo".into(),
+        effects: vec![],
+    }],
+    constraints: vec![],
+    metrics: Default::default(),
+    metric_plans: vec![],
+};
+
+# tokio_test::block_on(async {
+let output = runtime.run_pipeline_async(&plan, json!("hello")).await?;
+assert_eq!(output, json!("hello"));
+# Ok::<(), tupa_runtime::RuntimeError>(())
+# });
 ```
 
-Use this crate together with execution plans produced by `tupa-codegen`.
+Use this crate together with validated execution plans produced by `tupa-codegen`.
 
 ## Crate
 

--- a/docs/en/features/trading_support.md
+++ b/docs/en/features/trading_support.md
@@ -1,6 +1,6 @@
 # Trading Bot Support in Tupã
 
-This document details the features implemented in the Tupã Runtime (v0.8.1-dev) specifically to support algorithmic trading applications like `ViperTrade`.
+This document details the features implemented in the Tupã Runtime for the `0.8.1` line, specifically to support algorithmic trading applications like `ViperTrade`.
 
 See also the `0.8.1` strategy-modeling RFC:
 
@@ -114,14 +114,21 @@ Example shape:
 
 ```text
 input: {
-  signal: {
-    observed: bool,
-    consecutive_hits: i64,
-    required_hits: i64
-  },
-  guards: {
-    cooldown_active: bool,
-    remaining_ticks: i64
+  temporal: {
+    signal_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    cooldown_guard: {
+      active: bool,
+      remaining_seconds: i64
+    },
+    thesis_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    }
   }
 }
 ```

--- a/docs/en/reference/versioning.md
+++ b/docs/en/reference/versioning.md
@@ -23,7 +23,7 @@ Release candidates use the `vX.Y.Z-rc.N` format and must be treated as pre-GA bu
 - RC tags publish release artifacts for validation.
 - API guarantees are limited to documented stable surfaces.
 
-## Distribution Model (v0.8.0-rc)
+## Distribution Model (v0.8.1)
 
 Tupa uses a hybrid model:
 

--- a/docs/es/features/trading_support.md
+++ b/docs/es/features/trading_support.md
@@ -1,6 +1,6 @@
 ﻿# Soporte para Bots de Trading en Tupã
 
-Este documento detalla las funcionalidades implementadas en Tupã Runtime (v0.8.1-dev) para soportar aplicaciones de trading algorítmico como `ViperTrade`.
+Este documento detalla las funcionalidades implementadas en Tupã Runtime para la línea `0.8.1`, orientadas a soportar aplicaciones de trading algorítmico como `ViperTrade`.
 
 ## Resumen
 
@@ -110,14 +110,21 @@ Shape de ejemplo:
 
 ```text
 input: {
-  signal: {
-    observed: bool,
-    consecutive_hits: i64,
-    required_hits: i64
-  },
-  guards: {
-    cooldown_active: bool,
-    remaining_ticks: i64
+  temporal: {
+    signal_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    cooldown_guard: {
+      active: bool,
+      remaining_seconds: i64
+    },
+    thesis_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    }
   }
 }
 ```

--- a/docs/es/reference/versioning.md
+++ b/docs/es/reference/versioning.md
@@ -23,7 +23,7 @@ Los release candidates usan el formato `vX.Y.Z-rc.N` y deben tratarse como build
 - Los tags RC publican artifacts de release para validación.
 - Las garantías de API se limitan a superficies estables documentadas.
 
-## Modelo de distribución (v0.8.0-rc)
+## Modelo de distribución (v0.8.1)
 
 Tupa usa un modelo híbrido:
 

--- a/docs/pt-br/features/trading_support.md
+++ b/docs/pt-br/features/trading_support.md
@@ -1,6 +1,6 @@
 # Suporte a Bot de Trade no Tupã
 
-Este documento detalha as funcionalidades implementadas no Runtime do Tupã (v0.8.1-dev) especificamente para suportar aplicações de trading algorítmico como o `ViperTrade`.
+Este documento detalha as funcionalidades implementadas no Runtime do Tupã para a linha `0.8.1`, especificamente para suportar aplicações de trading algorítmico como o `ViperTrade`.
 
 ## Visão Geral
 
@@ -110,14 +110,21 @@ Shape de exemplo:
 
 ```text
 input: {
-  signal: {
-    observed: bool,
-    consecutive_hits: i64,
-    required_hits: i64
-  },
-  guards: {
-    cooldown_active: bool,
-    remaining_ticks: i64
+  temporal: {
+    signal_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    },
+    cooldown_guard: {
+      active: bool,
+      remaining_seconds: i64
+    },
+    thesis_confirmation: {
+      observed: bool,
+      consecutive_hits: i64,
+      required_hits: i64
+    }
   }
 }
 ```

--- a/docs/pt-br/reference/versioning.md
+++ b/docs/pt-br/reference/versioning.md
@@ -23,7 +23,7 @@ Release candidates usam o formato `vX.Y.Z-rc.N` e devem ser tratados como builds
 - Tags RC publicam artefatos de release para validação.
 - Garantias de API ficam limitadas às superfícies estáveis documentadas.
 
-## Modelo de distribuição (v0.8.0-rc)
+## Modelo de distribuição (v0.8.1)
 
 Tupa usa um modelo híbrido:
 


### PR DESCRIPTION
## Summary
- improve crate READMEs that will be published to crates.io
- align trading support docs with the temporal policy shape used by ViperTrade
- clean up 0.8.1 versioning references across EN/ES/PT-BR docs

## Why now
This is release-quality polish for the 0.8.1 cut and improves the first-use experience for published crates.
