### PR TITLE
docs: add 0.8.1 post-release notes

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -42,5 +42,6 @@ Wiki pages mirror this directory (`docs/`). Avoid manual edits in the wiki.
 ## Internals & Planning
 
 - Releases: [Changelog](releases/changelog.md) • [Guide](releases/release_guide.md)
+- Retrospective: [Post-Release Notes: v0.8.1](releases/post_release_v0.8.1.md)
 - Planning: [RFC v0.8.1 Trading Strategy Support](releases/rfc_v0.8.1_trading_strategy_support.md)
 - Governance: [Hybrid Distribution Decision](governance/hybrid_distribution_decision.md)

--- a/docs/en/releases/changelog.md
+++ b/docs/en/releases/changelog.md
@@ -40,18 +40,19 @@ This document records relevant changes per version.
 
 ### Validation Snapshot (workspace)
 
-- Release-prep status: implementation merged on `main`, awaiting tag and published binary artifacts.
+- Release status: `v0.8.1` tag cut, crates published, and standalone artifacts released.
 - Validation status:
   - docs parity green
   - markdownlint green
   - CI green for merged language/runtime changes
-  - ViperTrade local CI green against the current `main`
+  - ViperTrade local CI green against the release line
+  - ViperTrade runtime aligned with the official standalone `v0.8.1` CLI release
 
 ### Technical Debt
 
 - Typed config access is solved pragmatically through structured `input`, not dedicated config-binding syntax.
 - Temporal policy remains declarative at the policy layer; host-managed state still lives outside the language runtime.
-- Release automation is ready, but the public `v0.8.1` tag and binary artifacts have not been cut yet.
+- Reusable policy ergonomics still depend mostly on normal functions and explicit record composition.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/en/releases/post_release_v0.8.1.md
+++ b/docs/en/releases/post_release_v0.8.1.md
@@ -1,0 +1,94 @@
+# Post-Release Notes: v0.8.1
+
+## Purpose
+
+This note captures what `v0.8.1` taught us after shipping the language, runtime, and
+`ViperTrade` integration together.
+
+## What Worked Well
+
+- `ViperTrade` served as a real functional proving ground for `TupaLang`.
+- Small, mergeable slices kept the release moving without losing confidence.
+- The sequence of features was coherent:
+  - structured outputs
+  - first-class reasons
+  - weighted score support
+  - typed config input pattern
+  - declarative temporal policy support
+- Release docs were tightened before the public tag, not after it.
+
+## Main Lessons
+
+### 1. The bottleneck was no longer data shape
+
+Once `record types`, `record literals`, typed field access, structured runtime validation,
+and weighted policy outputs were in place, the next gains did not come from more shape
+machinery.
+
+The real leverage came from:
+
+- making policy reusable
+- modeling temporal policy explicitly
+- passing typed host-provided state into the pipeline
+
+### 2. The host should keep operational state
+
+The `0.8.1` work confirmed that the language becomes more useful when it models policy,
+not when it tries to absorb all host state.
+
+Stateful concerns still belong in the host application:
+
+- signal confirmation counters
+- cooldown tracking
+- trailing-stop state
+- persistence and external side effects
+
+The language helped most when it could describe how that state should be interpreted.
+
+### 3. The pipeline became valuable once it reflected real shapes
+
+The `.tp` layer became materially more useful after it stopped being just an architectural
+placeholder and started receiving:
+
+- structured inputs
+- real temporal state snapshots
+- structured outputs consumed by the application runtime
+
+That turned the pipeline into a real contract instead of a future-looking design sketch.
+
+### 4. Standalone tooling must be validated early
+
+The local validation flow exposed an important operational lesson: if the validation path
+uses an outdated `tupa` binary, the pipeline appears broken even when the language changes
+are correct.
+
+Future feature work should keep these aligned early:
+
+- `tupa-cli`
+- local validation scripts
+- container images used by CI or compose workflows
+
+## What We Would Do Earlier Next Time
+
+- Align the standalone CLI and local validation path sooner.
+- Document the boundary between declarative policy and host-managed state earlier.
+- Add a few focused tests earlier for newly exposed structured outputs.
+
+## What v0.8.1 Achieved
+
+`v0.8.1` moved `TupaLang` from a pipeline runtime with basic governance into a more useful
+language for real strategy systems:
+
+- outputs can be structured and typed
+- reasons can be first-class
+- policy can be composed with weighted scores
+- temporal policy can be expressed declaratively
+- typed host-provided config can be modeled without new core syntax
+
+## Next Pressure Points
+
+The next meaningful gains are not more output-shape primitives. They are:
+
+- better ergonomics for reusable policy building blocks
+- continued refinement of the boundary between host state and declarative policy
+- deciding whether some internal structured breakdowns should become public contracts

--- a/docs/en/releases/roadmap.md
+++ b/docs/en/releases/roadmap.md
@@ -6,9 +6,9 @@ This document summarizes the project evolution plan.
 
 ## Short Term
 
-- Cut and publish the `v0.8.1` release artifacts and crates.
-- Validate ViperTrade against the official `v0.8.1` standalone CLI release.
+- Consolidate the `v0.8.1` release learnings into examples and docs.
 - Refine reusable predicate ergonomics on top of the new policy-modeling primitives.
+- Decide whether any structured policy breakdowns should become stable public contracts.
 
 - Consolidate SPEC v0.1 (fine-tuning and validated examples).
 - Improve the typechecker (constraints and diagnostics).

--- a/docs/en/summary.md
+++ b/docs/en/summary.md
@@ -10,4 +10,5 @@
 - [Tutorials](guides/tutorials.md)
 - [Changelog](releases/changelog.md)
 - [RFC v0.8.1 Trading Strategy Support](releases/rfc_v0.8.1_trading_strategy_support.md)
+- [Post-Release Notes: v0.8.1](releases/post_release_v0.8.1.md)
 - [Contribution Guide](../../CONTRIBUTING.md)

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -56,6 +56,7 @@ Las páginas del wiki se replican automáticamente desde `docs/`. Evita editar e
 - [Motor de auditoría](governance/audit_engine.md)
 - [Notas de diseño (IA)](overview/design_notes.md)
 - [Changelog](releases/changelog.md)
+- [Notas Post-Release: v0.8.1](releases/post_release_v0.8.1.md)
 - [RFC v0.8.1 Soporte para Estrategias de Trading](releases/rfc_v0.8.1_trading_strategy_support.md)
 - [Plan MVP](overview/mvp_plan.md)
 - [Plan de adopción](governance/adoption_plan.md)

--- a/docs/es/releases/changelog.md
+++ b/docs/es/releases/changelog.md
@@ -41,18 +41,19 @@ Registrar cambios relevantes por versión.
 
 ### Snapshot de Validación del Workspace
 
-- Estado de preparacion de release: implementacion mergeada en `main`, a la espera del tag y de los binarios publicos.
+- Estado del release: tag `v0.8.1` cortado, crates publicados y artefactos standalone liberados.
 - Estado de validacion:
   - docs parity en verde
   - markdownlint en verde
   - CI en verde para los cambios de lenguaje y runtime mergeados
-  - CI local de ViperTrade en verde contra el `main` actual
+  - CI local de ViperTrade en verde contra la linea del release
+  - runtime de ViperTrade alineado con la release oficial del CLI standalone `v0.8.1`
 
 ### Deuda Técnica
 
 - El acceso tipado a configuracion esta resuelto de forma pragmatica mediante `input` estructurado, no por sintaxis dedicada.
 - La politica temporal sigue siendo declarativa en la capa de policy; el estado del host sigue fuera del runtime del lenguaje.
-- La automatizacion de release esta lista, pero el tag publico `v0.8.1` y los binarios todavia no se han publicado.
+- La ergonomia de politica reutilizable sigue dependiendo sobre todo de funciones normales y composicion explicita de records.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/es/releases/post_release_v0.8.1.md
+++ b/docs/es/releases/post_release_v0.8.1.md
@@ -1,0 +1,94 @@
+# Notas Post-Release: v0.8.1
+
+## Propósito
+
+Esta nota resume lo que `v0.8.1` nos enseñó después de publicar la integración entre el
+lenguaje, el runtime y `ViperTrade`.
+
+## Lo que funcionó bien
+
+- `ViperTrade` sirvió como prueba funcional real para `TupaLang`.
+- Los slices pequeños y mergeables mantuvieron el release en movimiento sin perder confianza.
+- La secuencia de features fue coherente:
+  - outputs estructurados
+  - reasons de política de primera clase
+  - soporte de weighted score
+  - patrón de input tipado para config
+  - soporte declarativo de política temporal
+- La documentación del release se ajustó antes del tag público, no después.
+
+## Lecciones principales
+
+### 1. El cuello de botella ya no era el shape de los datos
+
+Una vez que `record types`, `record literals`, field access tipado, validación estructurada
+de runtime y outputs de política ponderados estuvieron listos, las siguientes ganancias ya
+no vinieron de más maquinaria de shape.
+
+La palanca real pasó a ser:
+
+- hacer la política reutilizable
+- modelar la política temporal de forma explícita
+- pasar estado tipado provisto por el host al pipeline
+
+### 2. El host debe conservar el estado operacional
+
+El trabajo de `0.8.1` confirmó que el lenguaje se vuelve más útil cuando modela política,
+no cuando intenta absorber todo el estado del host.
+
+Las preocupaciones stateful siguen perteneciendo a la aplicación host:
+
+- contadores de confirmación de señales
+- seguimiento de cooldown
+- estado del trailing stop
+- persistencia y side effects externos
+
+El lenguaje ayudó más cuando pudo describir cómo interpretar ese estado.
+
+### 3. El pipeline ganó valor cuando reflejó shapes reales
+
+La capa `.tp` se volvió materialmente más útil cuando dejó de ser solo un placeholder
+arquitectónico y empezó a recibir:
+
+- inputs estructurados
+- snapshots reales de estado temporal
+- outputs estructurados consumidos por el runtime de la aplicación
+
+Eso convirtió el pipeline en un contrato real y no en un boceto de diseño futuro.
+
+### 4. El tooling standalone debe validarse temprano
+
+El flujo de validación local expuso una lección operacional importante: si la ruta de
+validación usa un binario `tupa` desactualizado, el pipeline parece roto aunque los cambios
+del lenguaje sean correctos.
+
+El próximo trabajo debería alinear temprano:
+
+- `tupa-cli`
+- scripts locales de validación
+- imágenes de contenedor usadas por CI o compose
+
+## Qué haríamos antes la próxima vez
+
+- Alinear antes el CLI standalone y la ruta de validación local.
+- Documentar antes el límite entre política declarativa y estado gestionado por el host.
+- Añadir antes algunos tests enfocados para los nuevos outputs estructurados expuestos.
+
+## Qué logró v0.8.1
+
+`v0.8.1` movió a `TupaLang` desde un runtime de pipelines con gobernanza básica hacia un
+lenguaje más útil para sistemas reales de estrategia:
+
+- los outputs pueden ser estructurados y tipados
+- las reasons pueden ser de primera clase
+- la política se puede componer con weighted scores
+- la política temporal se puede expresar de forma declarativa
+- la config tipada provista por el host se puede modelar sin sintaxis nueva en el core
+
+## Próximos puntos de presión
+
+Las siguientes ganancias relevantes no vienen de más primitivas de shape. Vienen de:
+
+- mejor ergonomía para bloques reutilizables de política
+- seguir refinando el límite entre estado del host y política declarativa
+- decidir si algunos breakdowns estructurados internos deben convertirse en contratos públicos

--- a/docs/es/releases/roadmap.md
+++ b/docs/es/releases/roadmap.md
@@ -6,9 +6,9 @@ Resumir el plan de evolución del proyecto.
 
 ## Corto plazo
 
-- Cortar y publicar los artefactos y crates del release `v0.8.1`.
-- Validar ViperTrade contra la release oficial del CLI standalone `v0.8.1`.
+- Consolidar en docs y ejemplos lo aprendido con la release `v0.8.1`.
 - Refinar la ergonomia de predicados reutilizables sobre las nuevas primitivas de policy.
+- Decidir si algunos breakdowns estructurados deben convertirse en contratos publicos estables.
 
 - Consolidar la SPEC v0.1 (ajustes finos y ejemplos validados).
 - Mejorar el typechecker (restricciones y diagnósticos).

--- a/docs/es/summary.md
+++ b/docs/es/summary.md
@@ -13,6 +13,7 @@
 - [Tutoriales paso a paso](guides/tutorials.md)
 - [Changelog](releases/changelog.md)
 - [RFC v0.8.1 Soporte para Estrategias de Trading](releases/rfc_v0.8.1_trading_strategy_support.md)
+- [Notas Post-Release: v0.8.1](releases/post_release_v0.8.1.md)
 - [Plan MVP](overview/mvp_plan.md)
 - [Guía de contribución](../../CONTRIBUTING.md)
 - [Toda la documentación](index.md)

--- a/docs/pt-br/index.md
+++ b/docs/pt-br/index.md
@@ -12,6 +12,7 @@ Esta documentação é mantida alinhada com a versão em inglês e atualizada à
 
 - [Sumário (PT-BR)](summary.md)
 - [RFC v0.8.1 Suporte a Estratégias de Trading](releases/rfc_v0.8.1_trading_strategy_support.md)
+- [Notas Pós-Release: v0.8.1](releases/post_release_v0.8.1.md)
 
 ## Contribuição
 

--- a/docs/pt-br/releases/changelog.md
+++ b/docs/pt-br/releases/changelog.md
@@ -41,18 +41,19 @@ Registrar mudanças relevantes por versão.
 
 ### Snapshot de Validação do Workspace
 
-- Status de preparação de release: implementação mergeada na `main`, aguardando tag e binários públicos.
+- Status do release: tag `v0.8.1` cortada, crates publicados e artefatos standalone liberados.
 - Status de validação:
   - docs parity verde
   - markdownlint verde
   - CI verde para as mudanças de linguagem e runtime mergeadas
-  - CI local do ViperTrade verde contra a `main` atual
+  - CI local do ViperTrade verde contra a linha do release
+  - runtime do ViperTrade alinhado com a release oficial do CLI standalone `v0.8.1`
 
 ### Débito Técnico
 
 - O acesso tipado à configuração foi resolvido pragmaticamente por meio de `input` estruturado, não por sintaxe dedicada.
 - A política temporal continua declarativa na camada de policy; o estado do host continua fora do runtime da linguagem.
-- A automação de release está pronta, mas a tag pública `v0.8.1` e os binários ainda não foram publicados.
+- A ergonomia de política reutilizável ainda depende majoritariamente de funções normais e composição explícita de records.
 
 ## 0.8.0-rc.5 (2026-03-07)
 

--- a/docs/pt-br/releases/post_release_v0.8.1.md
+++ b/docs/pt-br/releases/post_release_v0.8.1.md
@@ -1,0 +1,94 @@
+# Notas Pós-Release: v0.8.1
+
+## Propósito
+
+Esta nota registra o que a `v0.8.1` nos ensinou depois de publicarmos a integração entre a
+linguagem, o runtime e o `ViperTrade`.
+
+## O que funcionou bem
+
+- o `ViperTrade` serviu como prova funcional real do `TupaLang`
+- slices pequenos e mergeáveis mantiveram o release andando sem perder confiança
+- a sequência de features foi coerente:
+  - outputs estruturados
+  - reasons de política como first-class
+  - suporte a weighted score
+  - padrão de input tipado para config
+  - suporte declarativo a política temporal
+- a documentação do release foi ajustada antes da tag pública, não depois
+
+## Lições principais
+
+### 1. O gargalo deixou de ser shape de dados
+
+Depois que `record types`, `record literals`, field access tipado, validação estruturada no
+runtime e outputs ponderados de política ficaram prontos, os próximos ganhos deixaram de vir
+de mais maquinaria de shape.
+
+A alavanca real passou a ser:
+
+- tornar a política reutilizável
+- modelar política temporal de forma explícita
+- passar estado tipado provido pelo host para o pipeline
+
+### 2. O host deve manter o estado operacional
+
+O trabalho da `0.8.1` confirmou que a linguagem fica mais útil quando modela política, e não
+quando tenta absorver todo o estado do host.
+
+Preocupações stateful continuam pertencendo à aplicação host:
+
+- contadores de confirmação de sinal
+- controle de cooldown
+- estado de trailing stop
+- persistência e efeitos externos
+
+A linguagem ajudou mais quando conseguiu descrever como esse estado deve ser interpretado.
+
+### 3. O pipeline ganhou valor quando passou a refletir shapes reais
+
+A camada `.tp` ficou materialmente mais útil quando deixou de ser só um placeholder
+arquitetural e passou a receber:
+
+- inputs estruturados
+- snapshots reais de estado temporal
+- outputs estruturados consumidos pelo runtime da aplicação
+
+Isso transformou o pipeline em um contrato real, e não em um rascunho de design futuro.
+
+### 4. O tooling standalone precisa entrar cedo na validação
+
+O fluxo de validação local expôs uma lição operacional importante: se o caminho de validação
+usa um binário `tupa` antigo, o pipeline parece quebrado mesmo quando as mudanças da linguagem
+estão corretas.
+
+No próximo ciclo, vale alinhar cedo:
+
+- `tupa-cli`
+- scripts locais de validação
+- imagens de contêiner usadas por CI ou compose
+
+## O que faríamos mais cedo na próxima vez
+
+- alinhar antes o CLI standalone e o caminho de validação local
+- documentar antes a fronteira entre política declarativa e estado gerenciado pelo host
+- adicionar antes alguns testes focados para os novos outputs estruturados expostos
+
+## O que a v0.8.1 entregou
+
+A `v0.8.1` moveu o `TupaLang` de um runtime de pipelines com governança básica para uma
+linguagem mais útil para sistemas reais de estratégia:
+
+- outputs podem ser estruturados e tipados
+- reasons podem ser first-class
+- política pode ser composta com weighted scores
+- política temporal pode ser expressa declarativamente
+- config tipada provida pelo host pode ser modelada sem nova sintaxe no core
+
+## Próximos pontos de pressão
+
+Os próximos ganhos relevantes não vêm de mais primitivas de shape. Eles vêm de:
+
+- melhor ergonomia para blocos reutilizáveis de política
+- continuar refinando a fronteira entre estado do host e política declarativa
+- decidir se alguns breakdowns estruturados internos devem virar contratos públicos

--- a/docs/pt-br/releases/roadmap.md
+++ b/docs/pt-br/releases/roadmap.md
@@ -6,9 +6,9 @@ Resumir o plano de evolução do projeto.
 
 ## Curto prazo
 
-- Cortar e publicar os artefatos e crates do release `v0.8.1`.
-- Validar o ViperTrade contra a release oficial do CLI standalone `v0.8.1`.
+- Consolidar em docs e exemplos os aprendizados da release `v0.8.1`.
 - Refinar a ergonomia de predicados reutilizáveis sobre as novas primitivas de policy.
+- Decidir se alguns breakdowns estruturados devem virar contratos públicos estáveis.
 
 - Consolidar a SPEC v0.1 (ajustes finos e exemplos validados).
 - Melhorar o typechecker (restrições e diagnósticos).

--- a/docs/pt-br/summary.md
+++ b/docs/pt-br/summary.md
@@ -12,5 +12,6 @@
 - [Embedding API](reference/embedding.md)
 - [Changelog](releases/changelog.md)
 - [RFC v0.8.1 Suporte a Estratégias de Trading](releases/rfc_v0.8.1_trading_strategy_support.md)
+- [Notas Pós-Release: v0.8.1](releases/post_release_v0.8.1.md)
 - [Decisão de distribuição híbrida](governance/hybrid_distribution_decision.md)
 - [Guia de contribuição](../../CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- add multilingual post-release notes for v0.8.1
- update changelog and roadmap to reflect the actual post-release state
- link the retrospective from the docs indexes

## Validation
- git diff --check
