### PR TITLE
fix: publish all crates on tag releases

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -80,7 +80,7 @@ jobs:
           done
 
   publish-cli:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_cli == 'true'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_cli == 'true')
     runs-on: ubuntu-latest
     needs: publish-core
     env:

--- a/crates/tupa-audit/README.md
+++ b/crates/tupa-audit/README.md
@@ -14,3 +14,8 @@ let hash = hash_execution(&program, &[json!({"x": 1})]);
 println!("{} {}", compiler_version(), hash);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-audit` together with the embedded Tupa runtime to hash and persist strategy execution diagnostics for recent trade and pipeline analysis.

--- a/crates/tupa-cli/README.md
+++ b/crates/tupa-cli/README.md
@@ -20,3 +20,8 @@ tupa run path/to/file.tp
 
 - Binary name: `tupa`
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-cli` in local and CI validation flows to typecheck and validate strategy pipelines before runtime deployment.

--- a/crates/tupa-codegen/README.md
+++ b/crates/tupa-codegen/README.md
@@ -23,3 +23,8 @@ Run `tupa-typecheck` before generating plans so the execution plan is produced f
 ## Crate
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-codegen` in-process to build execution plans for strategy and analyst pipelines that run inside Rust services.

--- a/crates/tupa-effects/README.md
+++ b/crates/tupa-effects/README.md
@@ -8,3 +8,8 @@ This crate exposes shared effect definitions used across the TupaLang toolchain.
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses the shared Tupa effect model as part of its embedded runtime/tooling stack for strategy execution and diagnostics.

--- a/crates/tupa-fmt/README.md
+++ b/crates/tupa-fmt/README.md
@@ -10,3 +10,8 @@ use tupa_fmt::format_source;
 let out = format_source("fn main(){return;}");
 println!("{}", out);
 ```
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade is the main applied integration reference for TupaLang strategy authoring; `tupa-fmt` supports that workflow when formatting `.tp` sources in local development and editor tooling.

--- a/crates/tupa-lexer/README.md
+++ b/crates/tupa-lexer/README.md
@@ -16,3 +16,8 @@ println!("{} tokens", tokens.len());
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
 - License: Apache-2.0
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade depends on the parser/typecheck/runtime stack built on top of `tupa-lexer` for embedded strategy and diagnostics pipelines.

--- a/crates/tupa-lint/README.md
+++ b/crates/tupa-lint/README.md
@@ -13,3 +13,8 @@ let warnings = lint_program(&program);
 println!("{} warnings", warnings.len());
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade is the applied reference integration for TupaLang pipelines; `tupa-lint` fits into that workflow for pre-runtime quality checks on `.tp` sources.

--- a/crates/tupa-parser/README.md
+++ b/crates/tupa-parser/README.md
@@ -16,3 +16,8 @@ println!("{} top-level items", program.items.len());
 
 - Depends on `tupa-lexer`
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-parser` as part of its embedded pipeline compilation path for strategies and analyst diagnostics.

--- a/crates/tupa-pyffi/README.md
+++ b/crates/tupa-pyffi/README.md
@@ -18,3 +18,8 @@ assert_eq!(result, json!(4.0));
 - Requires Python runtime/toolchain in build or runtime environment.
 - Calls a Python function with a single JSON-like argument and converts the return value back to `serde_json::Value`.
 - The target module must be importable from the active Python environment.
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade is the main applied integration reference for embedded Tupa pipelines; `tupa-pyffi` is available when those pipelines need Python-backed enrichment or interoperability.

--- a/crates/tupa-runtime/README.md
+++ b/crates/tupa-runtime/README.md
@@ -48,3 +48,8 @@ Use this crate together with validated execution plans produced by `tupa-codegen
 ## Crate
 
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-runtime` as an embedded execution engine inside the strategy and AI analyst services, rather than spawning `tupa run` per event.

--- a/crates/tupa-typecheck/README.md
+++ b/crates/tupa-typecheck/README.md
@@ -17,3 +17,8 @@ typecheck_program(&program)?;
 
 - Works with `tupa-parser` AST
 - Source: [tupalang](https://github.com/marciopaiva/tupalang)
+
+## Applied usage
+
+- Applied reference repository: [ViperTrade](https://github.com/marciopaiva/vipertrade)
+- ViperTrade uses `tupa-typecheck` to validate strategy and diagnostics pipelines before code generation and embedded runtime execution.


### PR DESCRIPTION
## Summary
- add applied ViperTrade references to crate READMEs
- publish CLI and audit crates on tag releases, not only on manual dispatch
- keep manual workflow_dispatch support for selective CLI publishing

## Why
The v0.8.1 release published the core crates on tag push, but left `tupa-audit` at `0.8.0` and did not publish `tupa-cli`, `tupa-fmt`, or `tupa-lint` because the CLI publish job only ran on manual dispatch. This change closes that gap for future tags while also improving crates.io README context with an applied integration reference.

## Validation
- `git diff --check`
- verified crates.io state via API for core vs CLI crates
- reviewed workflow conditions in `.github/workflows/publish-crates.yml`