### PR TITLE
chore(publish): include tupa-plugin in release workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -75,7 +75,8 @@ jobs:
             tupa-typecheck \
             tupa-codegen \
             tupa-pyffi \
-            tupa-runtime; do
+            tupa-runtime \
+            tupa-plugin; do
             publish_crate "$crate"
           done
 

--- a/crates/tupa-plugin/Cargo.toml
+++ b/crates/tupa-plugin/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Dynamic plugin loading for TupaLang step functions"
 license = "Apache-2.0"
 repository = "https://github.com/marciopaiva/tupalang"
+homepage = "https://github.com/marciopaiva/tupalang"
+documentation = "https://github.com/marciopaiva/tupalang/wiki"
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
Add tupa-plugin to the publish-crates workflow so it gets published along with other crates on v0.8.2 tag.

## Changes
- Update `.github/workflows/publish-crates.yml` to include `tupa-plugin` in core crates list
- Ensure crate has complete metadata (`repository`, `homepage`, `documentation`, `readme`)

## Test plan
- [x] cargo fmt, clippy, test pass
- [x] Verify `tupa-plugin` compiles and tests pass
- [ ] CI workflow validation (expected)
- [ ] Dry-run publish (workflow input)

Part of v0.8.2 release preparation.