### PR TITLE
fix: use tupa-cli for legacy commands in update-goldens

### DIFF
--- a/scripts/update-goldens.sh
+++ b/scripts/update-goldens.sh
@@ -14,19 +14,19 @@ normalize() {
 run_and_save_stdout() {
   local out_file="$1"; shift
   echo "Running: cargo run -p tupa-cli -- $*" >&2
-  CARGO_TERM_QUIET=true cargo run -q -p cargo-tupa -- "$@" | normalize > "$EXPECTED_DIR/$out_file"
+  CARGO_TERM_QUIET=true cargo run -q -p tupa-cli -- "$@" | normalize > "$EXPECTED_DIR/$out_file"
   echo "Wrote $EXPECTED_DIR/$out_file" >&2
 }
 
 run_and_save_stderr() {
   local out_file="$1"; shift
   echo "Running (expect failure): cargo run -p tupa-cli -- $*" >&2
-  if CARGO_TERM_QUIET=true cargo run -q -p cargo-tupa -- "$@" 1>/dev/null 2>/dev/null; then
+  if CARGO_TERM_QUIET=true cargo run -q -p tupa-cli -- "$@" 1>/dev/null 2>/dev/null; then
     echo "Command unexpectedly succeeded: $*" >&2
     exit 1
   fi
   # capture stderr
-  (CARGO_TERM_QUIET=true cargo run -q -p cargo-tupa -- "$@" 2>&1 1>/dev/null || true) | normalize > "$EXPECTED_DIR/$out_file"
+  (CARGO_TERM_QUIET=true cargo run -q -p tupa-cli -- "$@" 2>&1 1>/dev/null || true) | normalize > "$EXPECTED_DIR/$out_file"
   echo "Wrote $EXPECTED_DIR/$out_file" >&2
 }
 


### PR DESCRIPTION
The update-goldens.sh script incorrectly used cargo-tupa which doesn't support lex/parse/audit/etc. Switch back to tupa-cli for legacy .tp tooling.