### PR TITLE
fix(publish): remove dev-dependencies on workspace crates for 0.9.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -1580,7 +1580,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tupa-core-macros",
- "tupa-engine",
 ]
 
 [[package]]
@@ -1592,8 +1591,6 @@ dependencies = [
  "syn",
  "thiserror",
  "tokio",
- "tupa-core",
- "tupa-engine",
 ]
 
 [[package]]

--- a/crates/tupa-core-macros/Cargo.toml
+++ b/crates/tupa-core-macros/Cargo.toml
@@ -20,8 +20,6 @@ proc-macro2 = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-tupa-core = { path = "../tupa-core", version = "0.9.2" }
-tupa-engine = { path = "../tupa-engine" }
 tokio = { version = "1.0", features = ["full"] }
 
 [features]

--- a/crates/tupa-core/Cargo.toml
+++ b/crates/tupa-core/Cargo.toml
@@ -14,7 +14,6 @@ tupa-core-macros = { path = "../tupa-core-macros", version = "0.9.2" }
 serde_json = "1.0"
 
 [dev-dependencies]
-tupa-engine = { path = "../tupa-engine" }
 tokio = { version = "1.0", features = ["full"] }
 
 [features]

--- a/crates/tupa-engine/Cargo.toml
+++ b/crates/tupa-engine/Cargo.toml
@@ -17,7 +17,6 @@ thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-tupa-core = { path = "../tupa-core" }
 criterion = { version = "0.5", features = ["async"] }
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
The dev-dependencies in tupa-core-macros, tupa-core, and tupa-engine reference other workspace crates that are not yet published. With --locked, cargo publish fails because these crates are not available on crates.io. Removing these dev-deps temporarily allows the release to proceed. They will be restored after 0.9.2 is out.